### PR TITLE
Try fixing render-readme workflow

### DIFF
--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -43,9 +43,9 @@ jobs:
               packagename = read.dcf("DESCRIPTION", "Package"), 
               gh_repo = Sys.getenv("GITHUB_REPOSITORY")
             ), 
-            "README.Rmd"
+            "README_expanded.Rmd"
           )
-          rmarkdown::render("README.Rmd", output_file = "README.md", output_dir = ".")
+          rmarkdown::render("README_expanded.Rmd", output_file = "README.md", output_dir = ".")
         shell: Rscript {0}
         
       - name: Commit files

--- a/README.Rmd
+++ b/README.Rmd
@@ -47,7 +47,7 @@ pak::pak("{{ gh_repo }}")
 
 ## Quick start
 
-Here we show an example of using _{{ packagename }}_ to model an epidemic in the U.K population with an $R_0$ similar to that of pandemic influenza, with heterogeneity in social contacts among different age groups, and with the implementation of school closures to dampen the spread of the infection.
+Here we show an example of using _{{ packagename }}_ to model an epidemic in the U.K. population with an $R_0$ similar to that of pandemic influenza, with heterogeneity in social contacts among different age groups, and with the implementation of school closures to dampen the spread of the infection.
 
 ```{r}
 # load epidemics


### PR DESCRIPTION
This PR attempts to fix the render-readme workflow on `main` by expanding the Readme.Rmd to an untracked file, and rendering from that file to prevent `git` based errors.