### PR TITLE
Fix partial matching check_args_default.R

### DIFF
--- a/R/check_args_default.R
+++ b/R/check_args_default.R
@@ -53,7 +53,7 @@
   )
   # check that compartments sum to 1.0
   checkmate::assert_numeric(
-    rowSums(mod_args$population$initial_condition),
+    rowSums(mod_args$population$initial_conditions),
     lower = 1.0 - 1e-6, upper = 1.0 + 1e-6 # specify tolerance manually
   )
   # TODO: more input checking to be added
@@ -69,7 +69,7 @@
   # scale the contact matrix by the maximum real eigenvalue
   mod_args$population$contact_matrix <-
     mod_args$population$contact_matrix /
-      max(Re(eigen(mod_args$population$contact_matrix)$value))
+      max(Re(eigen(mod_args$population$contact_matrix)$values))
 
   # scale rows of the contact matrix by the corresponding group population
   mod_args$population$contact_matrix <-


### PR DESCRIPTION
This fixes partial matching in a couple of places. I've just fixed two occurrences but it may be better to use `[[x]]` rather than `$x` to avoid this.