### PR TITLE
Remove covr from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,6 @@ Imports:
 Suggests: 
     bookdown,
     colorspace,
-    covr,
     ggplot2,
     knitr,
     rmarkdown,


### PR DESCRIPTION
The same way we don't include pkgdown in `Suggests`, we shouldn't include covr, which is only used as part of a user-invisible development process. This also removes some of the reverse dependency checking burden for this package.