### PR TITLE
Fix partial matching

### DIFF
--- a/R/check_args_vacamole.R
+++ b/R/check_args_vacamole.R
@@ -57,7 +57,7 @@
   # scale the contact matrix by the maximum real eigenvalue
   mod_args[["population"]][["contact_matrix"]] <-
     mod_args[["population"]][["contact_matrix"]] /
-      max(Re(eigen(mod_args[["population"]][["contact_matrix"]])$value))
+      max(Re(eigen(mod_args[["population"]][["contact_matrix"]])$values))
 
   # scale rows of the contact matrix by the corresponding group population
   mod_args[["population"]][["contact_matrix"]] <-

--- a/R/input_check_helpers.R
+++ b/R/input_check_helpers.R
@@ -183,7 +183,7 @@ assert_vaccination <- function(x, doses, population) {
   # all other elements are identical dims as `nu`
   checkmate::assert_matrix(
     x[["nu"]],
-    ncol = doses
+    ncols = doses
   )
 
   # if a population is provided, check that the rows of `nu`
@@ -192,7 +192,7 @@ assert_vaccination <- function(x, doses, population) {
     checkmate::assert_class(population, "population")
     checkmate::assert_matrix(
       x[["nu"]],
-      nrow = length(population[["demography_vector"]])
+      nrows = length(population[["demography_vector"]])
     )
   }
 
@@ -232,7 +232,7 @@ assert_intervention <- function(x, population) {
   checkmate::assert_matrix(
     x[["contact_reduction"]],
     mode = "numeric",
-    nrow = n_demo_groups
+    nrows = n_demo_groups
   )
 
   # invisibly return x

--- a/R/intervention.R
+++ b/R/intervention.R
@@ -104,11 +104,11 @@ validate_intervention <- function(object) {
   checkmate::assert_matrix(object$contact_reduction, mode = "numeric")
   checkmate::assert_matrix(
     object$time_begin,
-    ncol = ncol(object$contact_reduction), nrow = 1L
+    ncols = ncol(object$contact_reduction), nrows = 1L
   )
   checkmate::assert_matrix(
     object$time_end,
-    ncol = ncol(object$contact_reduction), nrow = 1L
+    ncols = ncol(object$contact_reduction), nrows = 1L
   )
 
   # stricter initialisation of interventions so that negative values and

--- a/R/population.R
+++ b/R/population.R
@@ -117,7 +117,7 @@ validate_population <- function(object) {
       checkmate::test_matrix(
         object$initial_conditions,
         mode = "numeric",
-        nrow = length(object$demography_vector)
+        nrows = length(object$demography_vector)
       ),
     "`initial_conditions` rows must always sum to 1.0" =
       (all(abs(rowSums(object$initial_conditions) - 1) < 1e-6))

--- a/tests/testthat/setup-options.R
+++ b/tests/testthat/setup-options.R
@@ -1,0 +1,7 @@
+# We want to flag partial matching as part of our testing & continuous
+# integration process because it makes code more brittle.
+options(
+  warnPartialMatchAttr = TRUE,
+  warnPartialMatchDollar = TRUE,
+  warnPartialMatchArgs = TRUE
+)

--- a/tests/testthat/test-infection.R
+++ b/tests/testthat/test-infection.R
@@ -37,6 +37,6 @@ test_that("Initialisation of the infection class", {
 test_that("Errors in infection initialisation", {
   expect_error(
     infection(r0 = 1.3, infectious_period = 5, preinfectious_period = c(3, 4)),
-    regex = "Error: All infection parameters must be the same length!"
+    regexp = "Error: All infection parameters must be the same length!"
   )
 })


### PR DESCRIPTION
This PR fixes partial matching in a number of instances, especially in {checkmate} functions. This PR fixes #66.