### PR TITLE
Further fixes for the ebola model

### DIFF
--- a/R/epidemic_default.R
+++ b/R/epidemic_default.R
@@ -38,7 +38,8 @@
 #' is a model parameter (see `infection`), and each element is a function with
 #' the first two arguments being the current simulation `time`, and `x`, a value
 #' that is dependent on `time` (`x` represents a model parameter).
-#' See **Details** for more information.
+#' See **Details** for more information, as well as the vignette on time-
+#' dependence \code{vignette("time_dependence", package = "epidemics")}.
 #' @param time_end The maximum number of timesteps over which to run the model.
 #' Taken as days, with a default value of 200 days.
 #' @param increment The size of the time increment. Taken as days, with a

--- a/R/epidemic_ebola.R
+++ b/R/epidemic_ebola.R
@@ -264,7 +264,7 @@ epidemic_ebola_r <- function(population, infection,
   }
 
   # define compartment names
-  compartments = c(
+  compartments <- c(
     "susceptible", "exposed", "infectious",
     "hospitalised", "funeral", "removed"
   )

--- a/R/epidemic_ebola.R
+++ b/R/epidemic_ebola.R
@@ -114,8 +114,7 @@ prob_discrete_erlang <- function(shape, rate) {
 #'
 #' @param time_dependence A named list where each name
 #' is a model parameter (see `infection`), and each element is a function with
-#' the first two arguments being the current simulation `time`, and `x`, a value
-#' that is dependent on `time` (`x` represents a model parameter).
+#' the first two arguments fixed as `time`, and `x`, followed by other arguments to be used by the supplied function. `time` is used internally to refer to the model time at which the named parameter will be changed.
 #' See **Details** for more information.
 #' @param time_end The maximum number of timesteps over which to run the model,
 #' in days. Defaults to 100 days.
@@ -181,7 +180,7 @@ prob_discrete_erlang <- function(shape, rate) {
 #' compartment, which holds both recoveries and deaths.
 #'
 #' We assume that deaths outside of hospital lead to funerals that are
-#' potentially not Ebola-safe, and the `funeral_risk` passed as part of the
+#' potentially unsafe burials, and the `funeral_risk` passed as part of the
 #' `infection` argument scales the baseline transmission rate \eqn{\beta} for
 #' funeral transmission of Ebola to susceptibles.
 #'

--- a/R/epidemic_ebola.R
+++ b/R/epidemic_ebola.R
@@ -114,8 +114,10 @@ prob_discrete_erlang <- function(shape, rate) {
 #'
 #' @param time_dependence A named list where each name
 #' is a model parameter (see `infection`), and each element is a function with
-#' the first two arguments fixed as `time`, and `x`, followed by other arguments to be used by the supplied function. `time` is used internally to refer to the model time at which the named parameter will be changed.
-#' See **Details** for more information.
+#' the first two arguments being the current simulation `time`, and `x`, a value
+#' that is dependent on `time` (`x` represents a model parameter).
+#' See **Details** for more information, as well as the vignette on time-
+#' dependence \code{vignette("time_dependence", package = "epidemics")}.
 #' @param time_end The maximum number of timesteps over which to run the model,
 #' in days. Defaults to 100 days.
 #' @return
@@ -261,6 +263,12 @@ epidemic_ebola_r <- function(population, infection,
     )
   }
 
+  # define compartment names
+  compartments = c(
+    "susceptible", "exposed", "infectious",
+    "hospitalised", "funeral", "removed"
+  )
+
   # set Erlang shape parameters, k^E and k^I; this is a modelling decision
   shape_E <- 2L
   shape_I <- 2L
@@ -279,17 +287,12 @@ epidemic_ebola_r <- function(population, infection,
 
   # round to nearest integer
   initial_state <- round(initial_state)
-  names(initial_state) <- c(
-    "susceptible", "exposed", "infectious",
-    "hospitalised", "funeral", "removed"
-  )
+  names(initial_state) <- compartments
 
   # prepare output data.frame
   population_size <- sum(initial_state)
-  sim_data <- matrix(NA_integer_, nrow = time_end, ncol = 6L)
-  colnames(sim_data) <- c(
-    "susceptible", "exposed", "infectious", "hospitalised", "funeral", "removed"
-  )
+  sim_data <- matrix(NA_integer_, nrow = time_end, ncol = length(compartments))
+  colnames(sim_data) <- compartments
 
   # assign initial conditions
   sim_data[1, ] <- initial_state

--- a/R/epidemic_ebola.R
+++ b/R/epidemic_ebola.R
@@ -269,23 +269,33 @@ epidemic_ebola_r <- function(population, infection,
     rate = rate_I
   )
 
-  # count number of exposed and infectious blocks or boxcars
-  n_exposed_boxcars <- length(exposed_boxcar_rates)
+  # count number of infectious blocks or boxcars
   n_infectious_boxcars <- length(infectious_boxcar_rates)
 
-  # prepare the current compartments
-  exposed_current <- numeric(n_exposed_boxcars)
-  infectious_current <- numeric(n_infectious_boxcars)
-  hospitalised_current <- numeric(n_infectious_boxcars)
-
   # initialise current conditions for exposed and infectious compartments
-  exposed_current[n_exposed_boxcars] <- sim_data[1, "exposed"]
+  exposed_current <- as.vector(
+    stats::rmultinom(
+      1,
+      size = sim_data[1, "exposed"],
+      prob = exposed_boxcar_rates
+    )
+  )
   exposed_past <- exposed_current
 
-  infectious_current[n_infectious_boxcars] <- sim_data[1, "infectious"]
+  infectious_current <- as.vector(
+    stats::rmultinom(1,
+      size = sim_data[1, "infectious"],
+      prob = infectious_boxcar_rates
+    )
+  )
   infectious_past <- infectious_current
 
-  hospitalised_current[n_infectious_boxcars] <- sim_data[1, "hospitalised"]
+  hospitalised_current <- as.vector(
+    stats::rmultinom(1,
+      size = sim_data[1, "hospitalised"],
+      prob = infectious_boxcar_rates
+    )
+  )
   hospitalised_past <- hospitalised_current
 
   funeral_trans_current <- sim_data[1, "funeral"]

--- a/R/epidemic_ebola.R
+++ b/R/epidemic_ebola.R
@@ -111,6 +111,12 @@ prob_discrete_erlang <- function(shape, rate) {
 #' parameters, such as the transmission rate, over the epidemic.
 #' See [intervention()] for details on constructing rate interventions.
 #' Defaults to `NULL`, representing no interventions on model parameters.
+#'
+#' @param time_dependence A named list where each name
+#' is a model parameter (see `infection`), and each element is a function with
+#' the first two arguments being the current simulation `time`, and `x`, a value
+#' that is dependent on `time` (`x` represents a model parameter).
+#' See **Details** for more information.
 #' @param time_end The maximum number of timesteps over which to run the model,
 #' in days. Defaults to 100 days.
 #' @return
@@ -184,6 +190,18 @@ prob_discrete_erlang <- function(shape, rate) {
 #'
 #' Individuals in the 'removed' compartment do no affect model dynamics.
 #'
+#' ## Implementing vaccination
+#'
+#' Vaccination cannot currently be implemented in this model as it does not have
+#' a "vaccinated" epidemiological compartment. This prevents the use of a
+#' `<vaccination>` object.
+#'
+#' Instead, users can use the `time_dependence` argument to pass a function that
+#' modifies model parameters --- specifically, the transmission rate --- in a
+#' way that is consistent with the effect of vaccination.
+#' An example is shown in the vignette about this model; run this code to open
+#' the vignette: \code{vignette("ebola_model", package = "epidemics")}
+#'
 #' @references
 #' Li, S.-L., Ferrari, M. J., Bjørnstad, O. N., Runge, M. C., Fonnesbeck, C. J.,
 #' Tildesley, M. J., Pannell, D., & Shea, K. (2019). Concurrent assessment of
@@ -197,7 +215,9 @@ prob_discrete_erlang <- function(shape, rate) {
 #'
 #' @export
 epidemic_ebola_r <- function(population, infection,
-                             intervention = NULL, time_end = 100) {
+                             intervention = NULL,
+                             time_dependence = NULL,
+                             time_end = 100) {
   # input checking for the ebola R model
   assert_population(
     population,
@@ -227,6 +247,18 @@ epidemic_ebola_r <- function(population, infection,
       min.len = 1,
       names = "unique", any.missing = FALSE,
       types = "rate_intervention"
+    )
+  }
+  # check that time-dependence functions are passed as a list with at least the
+  # arguments `time` and `x`
+  # time must be before x, and they must be first two args
+  if (!is.null(time_dependence)) {
+    checkmate::assert_list(time_dependence, "function")
+    invisible(
+      lapply(time_dependence, checkmate::check_function,
+        args = c("time", "x"),
+        ordered = TRUE
+      )
     )
   }
 
@@ -319,13 +351,27 @@ epidemic_ebola_r <- function(population, infection,
 
   ## Run the simulation from time t = 2 to t = time_end
   for (time in seq(2, time_end)) {
-    # check if an intervention is active
+    # make a copy to assign time-dependent and intervention-affected values
+    params <- parameters
+
+    # apply time dependence before interventions
+    time_dependent_params <- Map(
+      parameters[names(time_dependence)],
+      time_dependence,
+      f = function(x, func) {
+        func(time = time, x = x) # NOTE: time taken from loop index!
+      }
+    )
+    # assign time-modified param values
+    params[names(time_dependent_params)] <- time_dependent_params
+
+    # check if an intervention is active and apply it to rates
     params <- intervention_on_rates(
       t = time,
       interventions = intervention[
         setdiff(names(intervention), "contacts")
       ],
-      parameters = parameters
+      parameters = params
     )
 
     # transmission modifiers - 1.0 for baseline, user-provided for ETU risk and

--- a/R/epidemic_ebola.R
+++ b/R/epidemic_ebola.R
@@ -162,10 +162,11 @@ prob_discrete_erlang <- function(shape, rate) {
 #'
 #' ## Hospitalisation, funerals, and removal
 #'
-#' Infectious individuals have a probability of 1.0 - `prop_community` of being
-#' transferred to the hospitalised compartment, representing Ebola Treatment
-#' Units (ETUs), and are considered to be infectious but no longer in the
-#' community.
+#' A proportion, `1.0 - prop_community`, of infectious individuals are
+#' transferred to the hospitalised compartment in each timestep,
+#' This compartment represents Ebola Treatment Units (ETUs), and individuals
+#' in the hospitalised compartment are considered to be infectious but no longer
+#' in the community.
 #' This compartment has the same number of sub-compartments as the infectious
 #' compartment (i.e., infectious in the community), which means that
 #' an infectious individual with \eqn{N} timesteps before exiting the

--- a/R/epidemic_vacamole.R
+++ b/R/epidemic_vacamole.R
@@ -54,7 +54,8 @@
 #' is a model parameter (see `infection`), and each element is a function with
 #' the first two arguments being the current simulation `time`, and `x`, a value
 #' that is dependent on `time` (`x` represents a model parameter).
-#' See **Details** for more information.
+#' See **Details** for more information, as well as the vignette on time-
+#' dependence \code{vignette("time_dependence", package = "epidemics")}.
 #' @param time_end The maximum number of timesteps over which to run the model.
 #' Taken as days, with a default value of 200 days.
 #' @param increment The size of the time increment. Taken as days, with a

--- a/man/epidemic_default.Rd
+++ b/man/epidemic_default.Rd
@@ -54,7 +54,8 @@ See \code{\link[=vaccination]{vaccination()}}.}
 is a model parameter (see \code{infection}), and each element is a function with
 the first two arguments being the current simulation \code{time}, and \code{x}, a value
 that is dependent on \code{time} (\code{x} represents a model parameter).
-See \strong{Details} for more information.}
+See \strong{Details} for more information, as well as the vignette on time-
+dependence \code{vignette("time_dependence", package = "epidemics")}.}
 
 \item{time_end}{The maximum number of timesteps over which to run the model.
 Taken as days, with a default value of 200 days.}

--- a/man/epidemic_ebola.Rd
+++ b/man/epidemic_ebola.Rd
@@ -75,7 +75,8 @@ Defaults to \code{NULL}, representing no interventions on model parameters.}
 is a model parameter (see \code{infection}), and each element is a function with
 the first two arguments being the current simulation \code{time}, and \code{x}, a value
 that is dependent on \code{time} (\code{x} represents a model parameter).
-See \strong{Details} for more information.}
+See \strong{Details} for more information, as well as the vignette on time-
+dependence \code{vignette("time_dependence", package = "epidemics")}.}
 
 \item{time_end}{The maximum number of timesteps over which to run the model,
 in days. Defaults to 100 days.}
@@ -149,7 +150,7 @@ individuals exiting the hospitalised compartment move to the 'removed'
 compartment, which holds both recoveries and deaths.
 
 We assume that deaths outside of hospital lead to funerals that are
-potentially not Ebola-safe, and the \code{funeral_risk} passed as part of the
+potentially unsafe burials, and the \code{funeral_risk} passed as part of the
 \code{infection} argument scales the baseline transmission rate \eqn{\beta} for
 funeral transmission of Ebola to susceptibles.
 

--- a/man/epidemic_ebola.Rd
+++ b/man/epidemic_ebola.Rd
@@ -6,7 +6,13 @@
 \alias{epidemic_ebola_cpp}
 \title{Model an Ebola virus disease epidemic}
 \usage{
-epidemic_ebola_r(population, infection, intervention = NULL, time_end = 100)
+epidemic_ebola_r(
+  population,
+  infection,
+  intervention = NULL,
+  time_dependence = NULL,
+  time_end = 100
+)
 
 epidemic_ebola_cpp(population, infection, time_end = 100)
 }
@@ -64,6 +70,12 @@ pharmaceutical or non-pharmaceutical interventions applied to the infection's
 parameters, such as the transmission rate, over the epidemic.
 See \code{\link[=intervention]{intervention()}} for details on constructing rate interventions.
 Defaults to \code{NULL}, representing no interventions on model parameters.}
+
+\item{time_dependence}{A named list where each name
+is a model parameter (see \code{infection}), and each element is a function with
+the first two arguments being the current simulation \code{time}, and \code{x}, a value
+that is dependent on \code{time} (\code{x} represents a model parameter).
+See \strong{Details} for more information.}
 
 \item{time_end}{The maximum number of timesteps over which to run the model,
 in days. Defaults to 100 days.}
@@ -145,6 +157,19 @@ Individuals are assumed to spend only a single timestep in the funeral
 transmission compartment, before they move into the 'removed' compartment.
 
 Individuals in the 'removed' compartment do no affect model dynamics.
+}
+
+\subsection{Implementing vaccination}{
+
+Vaccination cannot currently be implemented in this model as it does not have
+a "vaccinated" epidemiological compartment. This prevents the use of a
+\verb{<vaccination>} object.
+
+Instead, users can use the \code{time_dependence} argument to pass a function that
+modifies model parameters --- specifically, the transmission rate --- in a
+way that is consistent with the effect of vaccination.
+An example is shown in the vignette about this model; run this code to open
+the vignette: \code{vignette("ebola_model", package = "epidemics")}
 }
 }
 

--- a/man/epidemic_ebola.Rd
+++ b/man/epidemic_ebola.Rd
@@ -130,10 +130,11 @@ beginning in one of the compartments (thus allowing for variation in passage
 times).
 \subsection{Hospitalisation, funerals, and removal}{
 
-Infectious individuals have a probability of 1.0 - \code{prop_community} of being
-transferred to the hospitalised compartment, representing Ebola Treatment
-Units (ETUs), and are considered to be infectious but no longer in the
-community.
+A proportion, \code{1.0 - prop_community}, of infectious individuals are
+transferred to the hospitalised compartment in each timestep,
+This compartment represents Ebola Treatment Units (ETUs), and individuals
+in the hospitalised compartment are considered to be infectious but no longer
+in the community.
 This compartment has the same number of sub-compartments as the infectious
 compartment (i.e., infectious in the community), which means that
 an infectious individual with \eqn{N} timesteps before exiting the

--- a/man/epidemic_ebola.Rd
+++ b/man/epidemic_ebola.Rd
@@ -31,18 +31,25 @@ infection,
 in days,
 \item \code{preinfectious_period}, a single number for the pre-infectious period
 before the onset of symptoms, taken to be in days,
-\item \code{prop_hospitalised}, a single number in the range 0.0 -- 1.0 for the
-proportion of infectious (assumed symptomatic) individuals who are
-hospitalised,
-\item \code{etu_safety}, a single number in the range 0.0 -- 1.0 for the relative
-effectiveness of hospitalisation (in an Ebola Treatment Unit; ETU) in
-reducing transmission between hospitalised individuals and susceptible ones.
-0.0 would indicate that hospitalisation does not reduce transmission, while
-1.0 would indicate that it completely prevents transmission.
-\item \code{funeral_safety}, a single number in the range 0.0 -- 1.0 for the relative
-efficacy of practices designed to prevent transmission of Ebola virus disease
-associated with funerals; alternatively interpretable as the proportion
-of funerals following these practices.
+\item \code{prop_community}, a single number in the range 0.0 -- 1.0 for the
+proportion of infectious (assumed symptomatic) individuals who are not
+hospitalised, and are instead infectious in the community,
+\item \code{etu_risk}, a single number in the range 0.0 -- 1.0 for the relative
+risk of EVD transmission in hospital settings (in Ebola Treatment Units; ETU)
+between hospitalised individuals and susceptible ones.
+This is understood to be a proportion of the baseline transmission rate
+\eqn{\beta}, which is calculated from the \verb{<infection>}.
+0.0 would indicate that hospitalisation completely eliminates transmission,
+while 1.0 would indicate that transmission between hospitalised individuals
+and susceptibles is the same as the baseline, which is transmission in the
+community.
+\item \code{funeral_risk}, a single number in the range 0.0 -- 1.0 for the relative
+risk of funeral practices that may lead to transmission of EVD in a funeral
+setting.
+This is understood to be a proportion of the baseline transmission rate
+\eqn{\beta}, which is calculated from the \verb{<infection>}. It can alternatively
+be interpreted as the proportion of funerals at which the risk of
+transmission is the same as of infectious individuals in the community.
 }
 
 \code{r0}, \code{infectious_period}, and \code{preinfectious_period} are used to calculate
@@ -56,9 +63,6 @@ See \strong{Details} for more information.}
 pharmaceutical or non-pharmaceutical interventions applied to the infection's
 parameters, such as the transmission rate, over the epidemic.
 See \code{\link[=intervention]{intervention()}} for details on constructing rate interventions.
-
-Currently, only interventions on the transmission rate \code{beta} are supported,
-and should be passed as \code{list(beta = intervention(type = "rate", ...))}.
 Defaults to \code{NULL}, representing no interventions on model parameters.}
 
 \item{time_end}{The maximum number of timesteps over which to run the model,
@@ -113,15 +117,18 @@ beginning in one of the compartments (thus allowing for variation in passage
 times).
 \subsection{Hospitalisation, funerals, and removal}{
 
-Infectious individuals have a probability of \code{prop_hospitalised} of being
-transferred to the hospitalised compartment.
-This compartment has the same number of sub-compartments, which means that
+Infectious individuals have a probability of 1.0 - \code{prop_community} of being
+transferred to the hospitalised compartment, representing Ebola Treatment
+Units (ETUs), and are considered to be infectious but no longer in the
+community.
+This compartment has the same number of sub-compartments as the infectious
+compartment (i.e., infectious in the community), which means that
 an infectious individual with \eqn{N} timesteps before exiting the
 infectious compartment will exit the hospitalised compartment in the same
 time.
 
 Hospitalised individuals can contribute to transmission of Ebola to
-susceptibles depending on the value of \code{etu_safety} passed as part of the
+susceptibles depending on the value of \code{etu_risk} passed as part of the
 \code{infection} argument, which scales the
 baseline transmission rate \eqn{\beta} for hospitalised individuals.
 
@@ -130,7 +137,7 @@ individuals exiting the hospitalised compartment move to the 'removed'
 compartment, which holds both recoveries and deaths.
 
 We assume that deaths outside of hospital lead to funerals that are
-potentially not Ebola-safe, and the \code{funeral_safety} passed as part of the
+potentially not Ebola-safe, and the \code{funeral_risk} passed as part of the
 \code{infection} argument scales the baseline transmission rate \eqn{\beta} for
 funeral transmission of Ebola to susceptibles.
 

--- a/man/epidemic_vacamole.Rd
+++ b/man/epidemic_vacamole.Rd
@@ -72,7 +72,8 @@ each dose. See \code{\link[=vaccination]{vaccination()}}.}
 is a model parameter (see \code{infection}), and each element is a function with
 the first two arguments being the current simulation \code{time}, and \code{x}, a value
 that is dependent on \code{time} (\code{x} represents a model parameter).
-See \strong{Details} for more information.}
+See \strong{Details} for more information, as well as the vignette on time-
+dependence \code{vignette("time_dependence", package = "epidemics")}.}
 
 \item{time_end}{The maximum number of timesteps over which to run the model.
 Taken as days, with a default value of 200 days.}

--- a/tests/testthat/test-ebola_model.R
+++ b/tests/testthat/test-ebola_model.R
@@ -17,9 +17,9 @@ ebola <- infection(
   r0 = 1.7,
   infectious_period = 7,
   preinfectious_period = 5,
-  prop_hospitalised = 0.5,
-  etu_safety = 0.8,
-  funeral_safety = 0.5
+  prop_community = 0.5,
+  etu_risk = 0.2,
+  funeral_risk = 0.5
 )
 
 # basic expectations
@@ -94,16 +94,16 @@ test_that("Larger R0 leads to larger final size in ebola model", {
     ebola_r0_low = infection(
       r0 = r0_low, infectious_period = 5,
       preinfectious_period = 5,
-      prop_hospitalised = 0.5,
-      etu_safety = 0.8,
-      funeral_safety = 0.5
+      prop_community = 0.5,
+      etu_risk = 0.2,
+      funeral_risk = 0.5
     ),
     ebola_r0_high = infection(
       r0 = r0_high + 1.0, infectious_period = 5,
       preinfectious_period = 5,
-      prop_hospitalised = 0.5,
-      etu_safety = 0.8,
-      funeral_safety = 0.5
+      prop_community = 0.5,
+      etu_risk = 0.2,
+      funeral_risk = 0.5
     )
   )
 
@@ -194,9 +194,9 @@ test_that("Ebola model with hospitalisation", {
     r0 = 1.7,
     infectious_period = 7,
     preinfectious_period = 5,
-    prop_hospitalised = 0.0,
-    etu_safety = 0.8,
-    funeral_safety = 0.5
+    prop_community = 1.0,
+    etu_risk = 0.2,
+    funeral_risk = 0.5
   )
   data <- epidemic_ebola_r(
     population = population,
@@ -227,9 +227,9 @@ test_that("Ebola model with hospitalisation", {
     r0 = 1.7,
     infectious_period = 7,
     preinfectious_period = 5,
-    prop_hospitalised = 1.0,
-    etu_safety = 1.0,
-    funeral_safety = 0.5
+    prop_community = 0.0,
+    etu_risk = 0.0,
+    funeral_risk = 0.5
   )
   # expect that the final size is the same as `total_cases` (20)
   data <- epidemic_ebola_r(
@@ -264,9 +264,9 @@ test_that("Ebola model with funeral safety", {
     r0 = 1.7,
     infectious_period = 7,
     preinfectious_period = 5,
-    prop_hospitalised = 0.0,
-    etu_safety = 0.0,
-    funeral_safety = 1.0
+    prop_community = 1.0,
+    etu_risk = 1.0,
+    funeral_risk = 0.0
   )
 
   # expect that the final size is the same as `total_cases` (20)

--- a/vignettes/ebola_model.Rmd
+++ b/vignettes/ebola_model.Rmd
@@ -355,7 +355,80 @@ ggplot(data_scenarios[compartment == "removed", ]) +
 ```
 
 We see that applying an intervention that reduces transmission can be effective in reducing the number of individuals infected over the outbreak.
-This model will soon be able to accommodate interventions that act on other processes, such as hospitalisation and funeral safety, to model the effect of campaigns to tackle these as sources of infections.
+
+## Modelling the roll-out of vaccination
+
+We can also model the rollout of vaccination against EVD, but because this model is structured differently from other models in _epidemics_, vaccination must be modelled differently too.
+
+`epidemic_ebola_r()` does not accept a vaccination regime as a `<vaccination>` object, but we can still model the effect of vaccination as a gradual decrease in the transmission rate $\beta$ over time.
+
+This is done by using the _time dependence_ functionality of _epidemics_.
+
+**NOTE ON TIME DEPENDENCE**
+
+We first define a function suitable for the `time_dependence` argument.
+This function assumes that the baseline transmission rate of ebola decreases over time, with a 5% reduction each day due to vaccination.
+
+```{r}
+# we assume a maximum time of 100 days, and a 5% daily reduction
+# we assume that this vaccination begins on the 15th day
+time_dep_vax <- function(
+    time, x, max_time = 100, time_start = 15,
+    reduction = 0.05) {
+  if (time < time_start) {
+    x
+  } else {
+    x * ((1.0 - reduction)^(time / max_time))
+  }
+}
+```
+
+```{r}
+# set a seed for comparison with the baseline model
+set.seed(0)
+# note that the intervention is passed within a list,
+# where it is named for the rate it is targeting
+data_apply_vax <- epidemic_ebola_r(
+  population = guinea_population,
+  infection = ebola,
+  time_dependence = list(
+    beta = time_dep_vax
+  ),
+  time_end = 100
+)
+
+# assign scenario name
+data_apply_vax$scenario <- "apply_vaccination"
+
+# bind the data together
+data_scenarios <- rbindlist(list(data_baseline, data_apply_vax))
+```
+
+```{r class.source = 'fold-hide', fig.cap="Effect of implementing a vaccination regime that gradually reduces ebola transmission over time, using the time dependence functionality."}
+ggplot(data_scenarios[compartment == "removed", ]) +
+  geom_vline(
+    xintercept = 15,
+    linetype = "dotted"
+  ) +
+  geom_line(
+    aes(time, value, colour = scenario)
+  ) +
+  scale_colour_brewer(
+    palette = "Set1",
+    name = "Scenario",
+    labels = c("Baseline", "Implementing vaccination")
+  ) +
+  theme_bw() +
+  theme(
+    legend.position = "top"
+  ) +
+  labs(
+    x = "Days",
+    y = "Outbreak size"
+  )
+```
+
+Similar functionality can be used to affect other model parameters more flexibly than allowed by the `<rate_intervention>` class.
 
 ## Modelling a multi-pronged ebola response
 

--- a/vignettes/ebola_model.Rmd
+++ b/vignettes/ebola_model.Rmd
@@ -364,7 +364,9 @@ We can also model the rollout of vaccination against EVD, but because this model
 
 This is done by using the _time dependence_ functionality of _epidemics_.
 
-**NOTE ON TIME DEPENDENCE**
+::: {.alert .alert-warning}
+**New to implementing parameter time dependence in _epidemics_?** It may help to read the [vignette on time dependence functionality](time_dependence.html) first!
+:::
 
 We first define a function suitable for the `time_dependence` argument.
 This function assumes that the baseline transmission rate of ebola decreases over time, with a 5% reduction each day due to vaccination.

--- a/vignettes/ebola_model.Rmd
+++ b/vignettes/ebola_model.Rmd
@@ -108,9 +108,9 @@ ebola <- infection(
   r0 = 1.5,
   infectious_period = 12,
   preinfectious_period = 5,
-  prop_hospitalised = 0.1,
-  etu_safety = 0.3,
-  funeral_safety = 0.5
+  prop_community = 0.9,
+  etu_risk = 0.7,
+  funeral_risk = 0.5
 )
 
 # print to visualise
@@ -287,13 +287,13 @@ We see that while some replicates affect over 600 individuals within the first 1
 
 An intervention that reduces transmission can be applied by passing a `<rate_intervention>` on the transmission rate parameter, `beta`.
 
-We model an intervention that begins 30 days into the outbreak, and reduces transmission by 20%. T
+We begin with an initial simple example that models an intervention that begins 15 days into the outbreak, and reduces transmission by 20%.
 
 ```{r}
 # create an intervention on the transmission rate
 reduce_transmission <- intervention(
   type = "rate",
-  time_begin = 30, time_end = 100, reduction = 0.2
+  time_begin = 15, time_end = 100, reduction = 0.2
 )
 ```
 
@@ -330,10 +330,10 @@ data_intervention$scenario <- "intervention"
 data_scenarios <- rbindlist(list(data_baseline, data_intervention))
 ```
 
-```{r class.source = 'fold-hide', fig.cap="Effect of implementing an intervention that reduces transmission by 30% during an ebola outbreak. The intervention begins on the 30th day (dotted vertical line), and is active for the remainder of the model duration. Applying this intervention leads to many fewer individuals infectious with ebola over the outbreak."}
-ggplot(data_scenarios[compartment == "infectious", ]) +
+```{r class.source = 'fold-hide', fig.cap="Effect of implementing an intervention that reduces transmission by 30% during an ebola outbreak. The intervention begins on the 15th day (dotted vertical line), and is active for the remainder of the model duration. Applying this intervention leads to many fewer individuals infectious with ebola over the outbreak."}
+ggplot(data_scenarios[compartment == "removed", ]) +
   geom_vline(
-    xintercept = 30,
+    xintercept = 15,
     linetype = "dotted"
   ) +
   geom_line(
@@ -350,12 +350,255 @@ ggplot(data_scenarios[compartment == "infectious", ]) +
   ) +
   labs(
     x = "Days",
-    y = "Number of individuals infectious"
+    y = "Outbreak size"
   )
 ```
 
 We see that applying an intervention that reduces transmission can be effective in reducing the number of individuals infected over the outbreak.
 This model will soon be able to accommodate interventions that act on other processes, such as hospitalisation and funeral safety, to model the effect of campaigns to tackle these as sources of infections.
+
+## Modelling a multi-pronged ebola response
+
+Since EVD is a severe disease with a high case fatality risk, responses to an outbreak may require the simultaneous implementation of a number of measures to reduce transmission to end the outbreak quickly.
+
+We can use the EVD model and existing functionality in _epidemics_ to model the implementation of a multi-pronged response to ebola that aims to:
+
+- Improve detection of cases and hospitalise them,
+
+- Improve the safety of hospitals and reduce the risk of individuals being treated there passing on ebola to susceptibles in the community, and
+
+- Improve the safety of funeral practices to reduce the risk of transmission from individuals who died while infectious with ebola.
+
+Here, we show the effects of these interventions separately, before showing their combined effect.
+
+### Improving hospitalisation
+
+We first model an intervention that begins 30 days into the outbreak, and reduces the proportion of individuals who are infectious in the community by 30%, thus improving the proportion that are hospitalised.
+
+```{r}
+# create an intervention on the transmission rate
+improve_hospitalisation <- intervention(
+  type = "rate",
+  time_begin = 15, time_end = 100, reduction = 0.3
+)
+```
+
+We can pass the interventions to the model function's `intervention` argument as a named list, with the names indicating the infection parameters to target.
+
+```{r}
+# set a seed for comparison with the baseline model
+set.seed(0)
+# note that the intervention is passed within a list,
+# where it is named for the rate it is targeting
+data_improve_hosp <- epidemic_ebola_r(
+  population = guinea_population,
+  infection = ebola,
+  intervention = list(
+    prop_community = improve_hospitalisation
+  ),
+  time_end = 100
+)
+
+# assign scenario name
+data_improve_hosp$scenario <- "improve_hosp"
+
+# bind the data together
+data_scenarios <- rbindlist(list(data_baseline, data_improve_hosp))
+```
+
+```{r class.source = 'fold-hide', fig.cap="Effect of implementing an intervention that reduces the proportion of infectious cases in the community by transferring them to a hospitalisation setting."}
+ggplot(data_scenarios[compartment == "removed", ]) +
+  geom_vline(
+    xintercept = 15,
+    linetype = "dotted"
+  ) +
+  geom_line(
+    aes(time, value, colour = scenario)
+  ) +
+  scale_colour_brewer(
+    palette = "Set1",
+    name = "Scenario",
+    labels = c("Baseline", "Improve hospitalisation")
+  ) +
+  theme_bw() +
+  theme(
+    legend.position = "top"
+  ) +
+  labs(
+    x = "Days",
+    y = "Outbreak size"
+  )
+```
+
+### Improve ETU safety
+
+We next model an intervention to improve the safety of ETUs by reducing transmission risk by 70%, alongside the earlier improvement in hospitalisation.
+
+```{r}
+# create an intervention on the transmission rate
+improve_etu_safety <- intervention(
+  type = "rate",
+  time_begin = 15, time_end = 100, reduction = 0.7
+)
+```
+
+```{r}
+# set a seed for comparison with the baseline model
+set.seed(0)
+# note that the intervention is passed within a list,
+# where it is named for the rate it is targeting
+data_improve_etu <- epidemic_ebola_r(
+  population = guinea_population,
+  infection = ebola,
+  intervention = list(
+    etu_risk = improve_etu_safety
+  ),
+  time_end = 100
+)
+
+# assign scenario name
+data_improve_etu$scenario <- "improve_etu"
+
+# bind the data together
+data_scenarios <- rbindlist(list(data_baseline, data_improve_etu))
+```
+
+```{r class.source = 'fold-hide', fig.cap="Effect of implementing an intervention that reduces the risk of ebola transmission in a hospitalisation context."}
+ggplot(data_scenarios[compartment == "removed", ]) +
+  geom_vline(
+    xintercept = 15,
+    linetype = "dotted"
+  ) +
+  geom_line(
+    aes(time, value, colour = scenario)
+  ) +
+  scale_colour_brewer(
+    palette = "Set1",
+    name = "Scenario",
+    labels = c("Baseline", "Improve ETU safety")
+  ) +
+  theme_bw() +
+  theme(
+    legend.position = "top"
+  ) +
+  labs(
+    x = "Days",
+    y = "Outbreak size"
+  )
+```
+
+Note that the reason that this intervention has little to no effect is that it is only likely to be effective when the proportion of cases hospitalised is high.
+In this model, the large majority of cases remain in the community, and improving the safety of ETUs is not an effective intervention.
+
+### Improve funeral safety
+
+We next model an intervention to improve the safety of funeral practices, by reducing transmission risk associated with funerals by 50%.
+
+```{r}
+# create an intervention on the transmission rate
+reduce_funeral_risk <- intervention(
+  type = "rate",
+  time_begin = 15, time_end = 100, reduction = 0.5
+)
+```
+
+```{r}
+# set a seed for comparison with the baseline model
+set.seed(0)
+# note that the intervention is passed within a list,
+# where it is named for the rate it is targeting
+data_improve_funeral <- epidemic_ebola_r(
+  population = guinea_population,
+  infection = ebola,
+  intervention = list(
+    funeral_risk = reduce_funeral_risk
+  ),
+  time_end = 100
+)
+
+# assign scenario name
+data_improve_funeral$scenario <- "improve_funeral"
+
+# bind the data together
+data_scenarios <- rbindlist(list(data_baseline, data_improve_funeral))
+```
+
+```{r class.source = 'fold-hide', fig.cap="Effect of implementing an intervention that reduces the risk of ebola transmission in a funeral context."}
+ggplot(data_scenarios[compartment == "removed", ]) +
+  geom_vline(
+    xintercept = 30,
+    linetype = "dotted"
+  ) +
+  geom_line(
+    aes(time, value, colour = scenario)
+  ) +
+  scale_colour_brewer(
+    palette = "Set1",
+    name = "Scenario",
+    labels = c("Baseline", "Improve funeral safety")
+  ) +
+  scale_y_sqrt() +
+  theme_bw() +
+  theme(
+    legend.position = "top"
+  ) +
+  labs(
+    x = "Days",
+    y = "Outbreak size"
+  )
+```
+
+### Combined interventions
+
+```{r}
+# set a seed for comparison with the baseline model
+set.seed(0)
+# note that the intervention is passed within a list,
+# where it is named for the rate it is targeting
+data_combined_interventions <- epidemic_ebola_r(
+  population = guinea_population,
+  infection = ebola,
+  intervention = list(
+    beta = reduce_transmission,
+    prop_community = improve_hospitalisation,
+    etu_risk = improve_etu_safety,
+    funeral_risk = reduce_funeral_risk
+  ),
+  time_end = 100
+)
+
+# assign scenario name
+data_combined_interventions$scenario <- "combined_interventions"
+
+# bind the data together
+data_scenarios <- rbindlist(
+  list(data_baseline, data_combined_interventions)
+)
+```
+
+```{r class.source = 'fold-hide', fig.cap="Effect of implementing multiple simultaneous interventions to reduce transmission during an ebola outbreak, all beginning on the 15th day (dotted vertical line), and remaining active for the remainder of the model duration. Applying these interventions substantially reduces the final size of the outbreak, with a potential plateau in the outbreak size reached at 100 days."}
+ggplot(data_scenarios[compartment == "removed", ]) +
+  geom_vline(
+    xintercept = 30,
+    linetype = "dotted"
+  ) +
+  geom_line(
+    aes(time, value, colour = scenario)
+  ) +
+  scale_colour_brewer(
+    palette = "Set1",
+    name = "Scenario",
+    labels = c("Baseline", "Combined interventions")
+  ) +
+  theme_bw() +
+  theme(
+    legend.position = "top"
+  ) +
+  labs(
+    x = "Days",
+    y = "Outbreak size"
+  )
+```
 
 ## Details: Discrete-time ebola virus disease model
 

--- a/vignettes/ebola_model.Rmd
+++ b/vignettes/ebola_model.Rmd
@@ -418,7 +418,7 @@ ggplot(data_scenarios[compartment == "removed", ]) +
   scale_colour_brewer(
     palette = "Set1",
     name = "Scenario",
-    labels = c("Baseline", "Implementing vaccination")
+    labels = c("Baseline", "Vaccination campaign")
   ) +
   theme_bw() +
   theme(
@@ -430,19 +430,19 @@ ggplot(data_scenarios[compartment == "removed", ]) +
   )
 ```
 
-Similar functionality can be used to affect other model parameters more flexibly than allowed by the `<rate_intervention>` class.
+Similar functionality can be used to model other parameters more flexibly than allowed by the `<rate_intervention>` class.
 
 ## Modelling a multi-pronged ebola response
 
 Since EVD is a severe disease with a high case fatality risk, responses to an outbreak may require the simultaneous implementation of a number of measures to reduce transmission to end the outbreak quickly.
 
-We can use the EVD model and existing functionality in _epidemics_ to model the implementation of a multi-pronged response to ebola that aims to:
+We can use the EVD model and existing functionality in _epidemics_ to model the implementation of a multi-pronged response to ebola that aims to improve:
 
-- Improve detection of cases and hospitalise them,
+- detection and treatment of cases,
 
-- Improve the safety of hospitals and reduce the risk of individuals being treated there passing on ebola to susceptibles in the community, and
+- safety of hospitals and the risk of community transmission, and
 
-- Improve the safety of funeral practices to reduce the risk of transmission from individuals who died while infectious with ebola.
+- safety of funeral practices to reduce the risk of transmission from dead bodies.
 
 Here, we show the effects of these interventions separately, before showing their combined effect.
 
@@ -493,7 +493,7 @@ ggplot(data_scenarios[compartment == "removed", ]) +
   scale_colour_brewer(
     palette = "Set1",
     name = "Scenario",
-    labels = c("Baseline", "Improve hospitalisation")
+    labels = c("Baseline", "Improved hospitalisation")
   ) +
   theme_bw() +
   theme(

--- a/vignettes/ebola_model.Rmd
+++ b/vignettes/ebola_model.Rmd
@@ -448,7 +448,7 @@ Here, we show the effects of these interventions separately, before showing thei
 
 ### Improving hospitalisation
 
-We first model an intervention that begins 30 days into the outbreak, and reduces the proportion of individuals who are infectious in the community by 30%, thus improving the proportion that are hospitalised.
+We first model an intervention that begins 15 days into the outbreak, and reduces the proportion of individuals who are infectious in the community by 30%, thus improving the proportion that are hospitalised.
 
 ```{r}
 # create an intervention on the transmission rate
@@ -601,7 +601,7 @@ data_scenarios <- rbindlist(list(data_baseline, data_improve_funeral))
 ```{r class.source = 'fold-hide', fig.cap="Effect of implementing an intervention that reduces the risk of ebola transmission in a funeral context."}
 ggplot(data_scenarios[compartment == "removed", ]) +
   geom_vline(
-    xintercept = 30,
+    xintercept = 15,
     linetype = "dotted"
   ) +
   geom_line(
@@ -654,7 +654,7 @@ data_scenarios <- rbindlist(
 ```{r class.source = 'fold-hide', fig.cap="Effect of implementing multiple simultaneous interventions to reduce transmission during an ebola outbreak, all beginning on the 15th day (dotted vertical line), and remaining active for the remainder of the model duration. Applying these interventions substantially reduces the final size of the outbreak, with a potential plateau in the outbreak size reached at 100 days."}
 ggplot(data_scenarios[compartment == "removed", ]) +
   geom_vline(
-    xintercept = 30,
+    xintercept = 15,
     linetype = "dotted"
   ) +
   geom_line(


### PR DESCRIPTION
This PR contains further fixes to the ebola model:
1. Fixes #101 by randomising assignment of exposed, infectious, and hospitalised into the Erlang subcompartments,
2. Fixes #134 by modifying model structure to invert `prop_hospitalised`, `etu_safety` and `funeral_safety` to parameters representing risk, so that `<rate_intervention>`s can be used to reduce these values without allowing #109,
3. Fixes #111 by allowing time-dependence, along with a vignette section on using time-dependence to simulate vaccination.