### PR TITLE
Corrections to Vacamole model

### DIFF
--- a/R/check_args_vacamole.R
+++ b/R/check_args_vacamole.R
@@ -109,13 +109,13 @@
         )
     )
 
-    # check for any other intervention list element names
+    # check for any other intervention list element names - allow only
+    # primary model parameters and not derived ones
     checkmate::assert_names(
       names(mod_args[["intervention"]]),
       subset.of = c(
-        "transmissibility", "transmissibility_vax", "infectiousness_rate",
-        "hospitalisation_rate", "hospitalisation_rate_vax",
-        "mortality_rate", "mortality_rate_vax", "recovery_rate", "contacts"
+        "transmissibility", "infectiousness_rate", "hospitalisation_rate",
+        "mortality_rate", "recovery_rate", "contacts"
       )
     )
 
@@ -149,9 +149,17 @@
     )
   }
 
-  # handle time dependence if present
+  # handle time dependence if present and check for allowed primary parameters
   if (!"time_dependence" %in% names(mod_args)) {
     mod_args[["time_dependence"]] <- no_time_dependence()
+  } else {
+    checkmate::assert_names(
+      names(mod_args[["time_dependence"]]),
+      subset.of = c(
+        "transmissibility", "infectiousness_rate", "hospitalisation_rate",
+        "mortality_rate", "recovery_rate"
+      )
+    )
   }
 
   # return arguments invisibly

--- a/R/check_args_vacamole.R
+++ b/R/check_args_vacamole.R
@@ -150,9 +150,7 @@
   }
 
   # handle time dependence if present and check for allowed primary parameters
-  if (!"time_dependence" %in% names(mod_args)) {
-    mod_args[["time_dependence"]] <- no_time_dependence()
-  } else {
+  if ("time_dependence" %in% names(mod_args)) {
     checkmate::assert_names(
       names(mod_args[["time_dependence"]]),
       subset.of = c(
@@ -160,6 +158,8 @@
         "mortality_rate", "recovery_rate"
       )
     )
+  } else {
+    mod_args[["time_dependence"]] <- no_time_dependence()
   }
 
   # return arguments invisibly

--- a/man/model_vacamole.Rd
+++ b/man/model_vacamole.Rd
@@ -85,13 +85,13 @@ age-specific effects on social contacts, as well as for guidance on how to
 concatenate multiple overlapping interventions into a single \verb{<intervention>}
 object.}
 
-\item{vaccination}{A \verb{<vaccination>} object representing an optional
-vaccination regime with two doses followed during the course of the
+\item{vaccination}{A \verb{<vaccination>} object representing a
+vaccination regime with \strong{two doses} followed during the course of the
 epidemic, with a start and end time, and age-specific vaccination rates for
 each dose. See \code{\link[=vaccination]{vaccination()}}.}
 
 \item{time_dependence}{A named list where each name
-is a model parameter (see \code{infection}), and each element is a function with
+is a model parameter, and each element is a function with
 the first two arguments being the current simulation \code{time}, and \code{x}, a value
 that is dependent on \code{time} (\code{x} represents a model parameter).
 See \strong{Details} for more information, as well as the vignette on time-
@@ -176,16 +176,20 @@ vaccinated.
 }
 }
 
-\subsection{Implementing time-dependent parameters}{
+\subsection{Rate interventions and time-dependence}{
 
-Model rates or parameters can be made time-dependent by passing a function
-which modifies the parameter based on the current ODE simulation time.
-For example, a function that increases the transmission rate
-\code{transmissibility} could be passed as
-\code{time_dependence = list(transmissibility = function(time, x) x * time)}.
-This functionality may be used to model events that are expected to have some
-effect on model parameters, such as seasonality or annual schedules such as
-holidays.
+This model allows interventions on only the primary model rates:
+transmissibility, infectiousness rate, hospitalisation rate, mortality rate,
+and the recovery rate. Interventions on the secondary model rates calculated
+as vaccination-linked modifications of these rates cannot be targeted by rate
+interventions or time dependence.
+
+See the vignette on rate interventions to represent pharmaceutical
+interventions (\code{vignette("rate_interventions", package = "epidemics")})
+and the vignette on time dependence
+(\code{vignette("time_dependence", package = "epidemics")})
+for worked out examples on how to
+implement these features.
 }
 }
 \examples{

--- a/tests/testthat/test-vacamole.R
+++ b/tests/testthat/test-vacamole.R
@@ -162,12 +162,34 @@ test_that("Vacamole with no hospitalisation", {
 
 #### Test for Vacamole model run with wrong inputs ####
 test_that("Vacamole model errors correctly", {
+  # error because vaccination doses are wrong
   expect_error(
     model_vacamole_cpp(
-      model_name = "vacamole",
       population = uk_population,
-      vaccination = no_vaccination(uk_population, doses = 3L),
-      time_end = 400, increment = 1
+      vaccination = no_vaccination(uk_population, doses = 3L)
+    )
+  )
+
+  # error because disallowed model parameters are targeted
+  expect_error(
+    model_vacamole_cpp(
+      population = uk_population,
+      vaccination = no_vaccination(uk_population, doses = 2L),
+      intervention = list(
+        transmissibility = no_rate_intervention(), # works okay
+        transmissibility_vax = no_rate_intervention() # should error
+      )
+    )
+  )
+
+  expect_error(
+    model_vacamole_cpp(
+      population = uk_population,
+      vaccination = no_vaccination(uk_population, doses = 2L),
+      time_dependence = list(
+        transmissibility = no_time_dependence(), # works okay
+        transmissibility_vax = no_time_dependence() # should error
+      )
     )
   )
 })


### PR DESCRIPTION
This PR is WIP #143 and restricts the Vacamole model to rate interventions and time dependence only on primary model parameters such as transmissibility.

This PR also renames 'infection_params' to 'model_params' in the R code of the default model.