### PR TITLE
Corrections and code streamlining

### DIFF
--- a/R/check_args_default.R
+++ b/R/check_args_default.R
@@ -5,15 +5,11 @@
 #' @description Check and prepare the four main arguments to
 #' [model_default_cpp()] for use with [.model_default_cpp()].
 #'
-#' `.check_args_model_default()` adds an empty `<intervention>` and
-#' `<vaccination>` object if these are missing from the model arguments.
-#'
 #' @return
 #'
 #' `.check_args_model_default()` invisibly returns the model arguments passed
-#' in `mod_args`. If the model arguments did not previously contain elements
-#' named `intervention` and `vaccination`, these are added as dummy objects of
-#' the corresponding classes.
+#' in `mod_args`. Model functionalities, such as vaccination or interventions,
+#' passed as `NULL` are replaced with dummy values for internal functions.
 #'
 #' `.prepare_args_model_default()` returns a list of model arguments suitable
 #' for [.model_default_cpp()]. This is a named list consisting of:

--- a/R/check_args_vacamole.R
+++ b/R/check_args_vacamole.R
@@ -5,15 +5,11 @@
 #' @description Check and prepare the four main arguments to
 #' [model_vacamole_cpp()] for use with [.model_vacamole_cpp()].
 #'
-#' `.check_args_model_vacamole()` adds an empty `<intervention>` object if
-#' this is missing from the model arguments.
-#'
 #' @return
 #'
-#' `.check_args_model_vacamole()` invisibly returns the model arguments
-#' passed in `mod_args`. If the model arguments did not previously contain
-#' elements named `intervention` this is added as dummy objects of the
-#' corresponding classes.
+#' `.check_args_model_vacamole()` invisibly returns the model arguments passed
+#' in `mod_args`. Model functionalities, such as interventions,
+#' passed as `NULL` are replaced with dummy values for internal functions.
 #'
 #' `.prepare_args_model_vacamole()` returns a list of model arguments
 #' suitable for [.model_vacamole_cpp()]. This is a named list consisting of:

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -147,11 +147,11 @@ epidemic_size <- function(
   # input checking for data - this allows data.tables as well
   checkmate::assert_data_frame(
     data,
-    ncols = 4L, min.rows = 1, any.missing = FALSE
+    min.cols = 4L, min.rows = 1, any.missing = FALSE
   )
   checkmate::assert_names(
     colnames(data),
-    identical.to = c("time", "demography_group", "compartment", "value")
+    must.include = c("time", "demography_group", "compartment", "value")
   )
   checkmate::assert_logical(by_group, len = 1L)
   checkmate::assert_logical(include_deaths, len = 1L)
@@ -240,11 +240,11 @@ new_infections <- function(data,
   # input checking for data - this allows data.tables as well
   checkmate::assert_data_frame(
     data,
-    ncols = 4, min.rows = 1, any.missing = FALSE
+    min.cols = 4, min.rows = 1, any.missing = FALSE
   )
   checkmate::assert_names(
     colnames(data),
-    identical.to = c("time", "demography_group", "compartment", "value")
+    must.include = c("time", "demography_group", "compartment", "value")
   )
   checkmate::assert_character(
     compartments_from_susceptible,

--- a/R/input_check_helpers.R
+++ b/R/input_check_helpers.R
@@ -6,24 +6,26 @@
 #' to check the population parameters required by each model. This
 #' function is for internal use in argument checking functions.
 #'
-#' @param x A [population] object.
+#' @param x A `<population>` object.
 #' @param compartments A character vector giving the names of model compartments
 #' whose length is taken as the reference for the number of columns in the
 #' `initial_conditions` matrix in `x`.
+#' @param demography_vector An optional numeric vector whose length is used to
+#' check the length of the demography vector present in `x`.
 #'
 #' @keywords internal
 #'
-#' @return Silently returns the `population` object `x`.
+#' @return Silently returns the `<population>` object `x`.
 #' Primarily called for its side effects of throwing errors when `x` does not
 #' meet certain requirements.
-assert_population <- function(x, demography_groups = NULL, compartments) {
+assert_population <- function(x, compartments, demography_vector = NULL) {
   # check for input class
   checkmate::assert_class(x, "population")
 
   # check that population has a set number of demography groups
   checkmate::assert_numeric(
     get_parameter(x, "demography_vector"),
-    len = demography_groups # checked against NULL in most models
+    len = demography_vector # checked against NULL in most models
   )
 
   # check that population has as many compartments in initial conditions
@@ -31,7 +33,7 @@ assert_population <- function(x, demography_groups = NULL, compartments) {
   checkmate::assert_matrix(
     get_parameter(x, "initial_conditions"),
     mode = "numeric", # this is also checked when initialising a population
-    nrows = demography_groups, # this is NULL for most models
+    nrows = demography_vector, # this is NULL for most models
     ncols = length(compartments)
   )
 
@@ -49,16 +51,16 @@ assert_population <- function(x, demography_groups = NULL, compartments) {
 #'
 #' @param x A [vaccination] object.
 #' @param doses The number of doses expected in the vaccination object.
-#' @param population An optional argument which is a [population] object.
+#' @param population An optional argument which is a `<population>` object.
 #' When present, this is used to check whether the vaccination object `x` has
 #' corresponding values for each demographic group in `population`.
 #'
 #' @keywords internal
 #'
-#' @return Silently returns the `vaccination` object `x`.
+#' @return Silently returns the `<vaccination>` object `x`.
 #' Primarily called for its side effects of throwing errors when `x` does not
 #' meet certain requirements.
-assert_vaccination <- function(x, doses, population) {
+assert_vaccination <- function(x, doses, population = NULL) {
   # check for input class
   checkmate::assert_class(x, "vaccination")
   checkmate::assert_number(doses, finite = TRUE, lower = 1L)
@@ -73,7 +75,7 @@ assert_vaccination <- function(x, doses, population) {
 
   # if a population is provided, check that the rows of `nu`
   # match the number of demography groups
-  if (!missing(population)) {
+  if (!is.null(population)) {
     checkmate::assert_class(population, "population")
     checkmate::assert_matrix(
       get_parameter(x, "nu"),
@@ -103,38 +105,38 @@ assert_vaccination <- function(x, doses, population) {
 #'
 #' @keywords internal
 #'
-#' @return Silently returns the `intervention` object `x`.
+#' @return Silently returns the `<intervention>`-superclass object `x` of the
+#' same class as `x`, i.e., `<rate_intervention>` or `<contacts_intervention>`.
 #' Primarily called for its side effects of throwing errors when `x` does not
 #' meet certain requirements.
 assert_intervention <- function(x, type = c("contacts", "rate"),
-                                population) {
+                                population = NULL) {
   # check for input class
   type <- match.arg(type, several.ok = FALSE)
   switch(type,
-    contacts = checkmate::assert_class(x, "contacts_intervention"),
-    rate = checkmate::assert_class(x, "rate_intervention")
-  )
-
-  if (type == "contacts") {
-    # check the population
-    # check that the length of reduction is the same as the number
-    # of demographic groups
-    n_demo_groups <- NULL
-    if (!missing(population)) {
-      n_demo_groups <- length(get_parameter(population, "demography_vector"))
+    contacts = {
+      checkmate::assert_class(x, "contacts_intervention")
+      # check that the length of reduction is the same as the number
+      # of demographic groups
+      n_demo_groups <- NULL
+      if (!is.null(population)) {
+        n_demo_groups <- length(get_parameter(population, "demography_vector"))
+      }
+      checkmate::assert_matrix(
+        get_parameter(x, "reduction"),
+        mode = "numeric",
+        nrows = n_demo_groups
+      )
+    },
+    rate = {
+      checkmate::assert_class(x, "rate_intervention")
+      checkmate::assert_numeric(
+        get_parameter(x, "reduction"),
+        lower = 0.0, upper = 1.0,
+        len = length(get_parameter(x, "time_begin"))
+      )
     }
-    checkmate::assert_matrix(
-      get_parameter(x, "reduction"),
-      mode = "numeric",
-      nrows = n_demo_groups
-    )
-  } else if (type == "rate") {
-    checkmate::assert_numeric(
-      get_parameter(x, "reduction"),
-      lower = 0.0, upper = 1.0,
-      len = length(get_parameter(x, "time_begin"))
-    )
-  }
+  )
 
   # invisibly return x
   invisible(x)

--- a/R/intervention.R
+++ b/R/intervention.R
@@ -823,7 +823,7 @@ cumulative_rate_intervention <- function(t, time_begin, time_end, reduction) {
 #' simulation.
 #' @param parameters A named list of numeric parameters affected by
 #' `interventions`.
-#' This represents the infection parameters, such as the transmission rate,
+#' This represents the model parameters, such as the transmission rate,
 #' \eqn{\beta}, or the recovery rate, \eqn{\gamma}.
 #' @return A named list of the same length as `parameters`, with the same names.
 #' These parameters can then be used in a timestep of an ODE model.

--- a/R/model_default.R
+++ b/R/model_default.R
@@ -131,46 +131,43 @@ model_default_cpp <- function(population,
                               increment = 1) {
   # check class on required inputs
   checkmate::assert_class(population, "population")
+  # NOTE: model rates very likely bounded 0 - 1 but no upper limit set for now
   checkmate::assert_number(transmissibility, lower = 0, finite = TRUE)
   checkmate::assert_number(infectiousness_rate, lower = 0, finite = TRUE)
   checkmate::assert_number(recovery_rate, lower = 0, finite = TRUE)
+
+  # all intervention sub-classes pass check for intervention superclass
+  checkmate::assert_list(intervention, types = "intervention", null.ok = TRUE)
+  checkmate::assert_class(vaccination, "vaccination", null.ok = TRUE)
+
+  # check that time-dependence functions are passed as a list with at least the
+  # arguments `time` and `x`
+  # time must be before x, and they must be first two args
+  checkmate::assert_list(time_dependence, "function", null.ok = TRUE)
+  # lapply on null returns an empty list
+  invisible(
+    lapply(time_dependence, checkmate::assert_function,
+      args = c("time", "x"),
+      ordered = TRUE
+    )
+  )
 
   # check the time end and increment
   # restrict increment to lower limit of 1e-6
   checkmate::assert_number(time_end, lower = 0, finite = TRUE)
   checkmate::assert_number(increment, lower = 1e-6, finite = TRUE)
 
-  # collect population, infection, and model arguments passed as `...`
+  # collect all model arguments
   model_arguments <- list(
     population = population,
     transmissibility = transmissibility,
     infectiousness_rate = infectiousness_rate,
     recovery_rate = recovery_rate,
+    intervention = intervention,
+    vaccination = vaccination,
+    time_dependence = time_dependence,
     time_end = time_end, increment = increment
   )
-
-  # check class add intervention and vaccination if not NULL
-  if (!is.null(intervention)) {
-    checkmate::assert_list(intervention, types = "intervention")
-    model_arguments[["intervention"]] <- intervention
-  }
-  if (!is.null(vaccination)) {
-    checkmate::assert_class(vaccination, "vaccination")
-    model_arguments[["vaccination"]] <- vaccination
-  }
-  # check that time-dependence functions are passed as a list with at least the
-  # arguments `time` and `x`
-  # time must be before x, and they must be first two args
-  if (!is.null(time_dependence)) {
-    checkmate::assert_list(time_dependence, "function")
-    invisible(
-      lapply(time_dependence, checkmate::check_function,
-        args = c("time", "x"),
-        ordered = TRUE
-      )
-    )
-    model_arguments[["time_dependence"]] <- time_dependence
-  }
 
   # prepare checked arguments for function
   # this necessary as check_args adds intervention and vaccination
@@ -288,47 +285,43 @@ model_default_r <- function(population,
                             increment = 1) {
   # check class on required inputs
   checkmate::assert_class(population, "population")
+  # NOTE: model rates very likely bounded 0 - 1 but no upper limit set for now
+  checkmate::assert_number(transmissibility, lower = 0, finite = TRUE)
+  checkmate::assert_number(infectiousness_rate, lower = 0, finite = TRUE)
+  checkmate::assert_number(recovery_rate, lower = 0, finite = TRUE)
+
+  # all intervention sub-classes pass check for intervention superclass
+  checkmate::assert_list(intervention, types = "intervention", null.ok = TRUE)
+  checkmate::assert_class(vaccination, "vaccination", null.ok = TRUE)
+
+  # check that time-dependence functions are passed as a list with at least the
+  # arguments `time` and `x`
+  # time must be before x, and they must be first two args
+  checkmate::assert_list(time_dependence, "function", null.ok = TRUE)
+  # lapply on null returns an empty list
+  invisible(
+    lapply(time_dependence, checkmate::assert_function,
+      args = c("time", "x"),
+      ordered = TRUE
+    )
+  )
 
   # check the time end and increment
   # restrict increment to lower limit of 1e-6
   checkmate::assert_number(time_end, lower = 0, finite = TRUE)
   checkmate::assert_number(increment, lower = 1e-6, finite = TRUE)
 
-  # collect population, infection, and model arguments passed as `...`
+  # collect all model arguments
   model_arguments <- list(
     population = population,
     transmissibility = transmissibility,
     infectiousness_rate = infectiousness_rate,
     recovery_rate = recovery_rate,
-    time_end = time_end, increment = increment,
-    time_dependence = time_dependence
+    intervention = intervention,
+    vaccination = vaccination,
+    time_dependence = time_dependence,
+    time_end = time_end, increment = increment
   )
-
-  # check class add intervention and vaccination if not NULL
-  if (!is.null(intervention)) {
-    checkmate::assert_list(
-      intervention,
-      types = c("intervention", "list")
-    )
-    model_arguments[["intervention"]] <- intervention
-  }
-  if (!is.null(vaccination)) {
-    checkmate::assert_class(vaccination, "vaccination")
-    model_arguments[["vaccination"]] <- vaccination
-  }
-  # check that time-dependence functions are passed as a list with at least the
-  # arguments `time` and `x`
-  # time must be before x, and they must be first two args
-  if (!is.null(time_dependence)) {
-    checkmate::assert_list(time_dependence, "function")
-    invisible(
-      lapply(time_dependence, checkmate::check_function,
-        args = c("time", "x"),
-        ordered = TRUE
-      )
-    )
-    model_arguments[["time_dependence"]] <- time_dependence
-  }
 
   # prepare checked arguments for function
   # this necessary as check_args adds intervention and vaccination

--- a/R/model_default.R
+++ b/R/model_default.R
@@ -115,13 +115,22 @@ model_default_cpp <- function(population,
   checkmate::assert_number(recovery_rate, lower = 0, finite = TRUE)
 
   # all intervention sub-classes pass check for intervention superclass
-  checkmate::assert_list(intervention, types = "intervention", null.ok = TRUE)
+  # note intervention and time-dependence targets are checked in dedicated fn
+  checkmate::assert_list(
+    intervention,
+    types = "intervention", null.ok = TRUE,
+    any.missing = FALSE, names = "unique"
+  )
   checkmate::assert_class(vaccination, "vaccination", null.ok = TRUE)
 
   # check that time-dependence functions are passed as a list with at least the
   # arguments `time` and `x`
   # time must be before x, and they must be first two args
-  checkmate::assert_list(time_dependence, "function", null.ok = TRUE)
+  checkmate::assert_list(
+    time_dependence, "function",
+    null.ok = TRUE,
+    any.missing = FALSE, names = "unique"
+  )
   # lapply on null returns an empty list
   invisible(
     lapply(time_dependence, checkmate::assert_function,
@@ -269,13 +278,22 @@ model_default_r <- function(population,
   checkmate::assert_number(recovery_rate, lower = 0, finite = TRUE)
 
   # all intervention sub-classes pass check for intervention superclass
-  checkmate::assert_list(intervention, types = "intervention", null.ok = TRUE)
+  checkmate::assert_list(
+    intervention,
+    types = "intervention", null.ok = TRUE,
+    names = "unique", any.missing = FALSE
+  )
+  # specifics of vaccination doses are checked in dedicated function
   checkmate::assert_class(vaccination, "vaccination", null.ok = TRUE)
 
   # check that time-dependence functions are passed as a list with at least the
   # arguments `time` and `x`
   # time must be before x, and they must be first two args
-  checkmate::assert_list(time_dependence, "function", null.ok = TRUE)
+  checkmate::assert_list(
+    time_dependence, "function",
+    null.ok = TRUE,
+    names = "unique", any.missing = FALSE
+  )
   # lapply on null returns an empty list
   invisible(
     lapply(time_dependence, checkmate::assert_function,

--- a/R/model_ebola.R
+++ b/R/model_ebola.R
@@ -89,14 +89,11 @@ prob_discrete_erlang <- function(shape, rate) {
 #' funeral transmission is equivalent to transmission in the community.
 #' `funeral_risk` is used to scale the value of transmissibility for the
 #' transmissibility \eqn{\beta}. Defaults to 0.5.
-#' @param intervention An optional `<rate_intervention>` object representing
-#' pharmaceutical or non-pharmaceutical interventions applied to the infection's
-#' parameters, such as the transmission rate, over the epidemic.
-#' See [intervention()] for details on constructing rate interventions.
-#' Defaults to `NULL`, representing no interventions on model parameters.
-#'
+#' @param intervention A named list of `<rate_intervention>` objects
+#' representing optional pharmaceutical or non-pharmaceutical interventions
+#' applied to the model parameters listed above.
 #' @param time_dependence A named list where each name
-#' is a model parameter (see `infection`), and each element is a function with
+#' is a model parameter, and each element is a function with
 #' the first two arguments being the current simulation `time`, and `x`, a value
 #' that is dependent on `time` (`x` represents a model parameter).
 #' See **Details** for more information, as well as the vignette on time-
@@ -159,8 +156,7 @@ prob_discrete_erlang <- function(shape, rate) {
 #' compartment in the same time.
 #'
 #' Hospitalised individuals can contribute to transmission of Ebola to
-#' susceptibles depending on the value of `etu_risk` passed as part of the
-#' `infection` argument, which scales the
+#' susceptibles depending on the value of `etu_risk` which scales the
 #' baseline transmission rate \eqn{\beta} for hospitalised individuals.
 #'
 #' We assume that deaths in hospital lead to Ebola-safe funerals, and

--- a/R/model_vacamole.R
+++ b/R/model_vacamole.R
@@ -152,13 +152,22 @@ model_vacamole_cpp <- function(population,
   checkmate::assert_number(mort_reduction_vax, lower = 0, upper = 1)
 
   # all intervention sub-classes pass check for intervention superclass
-  checkmate::assert_list(intervention, types = "intervention", null.ok = TRUE)
+  # note intervention and time-dependence targets are checked in dedicated fns
+  checkmate::assert_list(
+    intervention,
+    types = "intervention", null.ok = TRUE,
+    names = "unique", any.missing = FALSE
+  )
   checkmate::assert_class(vaccination, "vaccination", null.ok = TRUE)
 
   # check that time-dependence functions are passed as a list with at least the
   # arguments `time` and `x`
   # time must be before x, and they must be first two args
-  checkmate::assert_list(time_dependence, "function", null.ok = TRUE)
+  checkmate::assert_list(
+    time_dependence, "function",
+    null.ok = TRUE,
+    any.missing = FALSE, names = "unique"
+  )
   # lapply on null returns an empty list
   invisible(
     lapply(time_dependence, checkmate::assert_function,
@@ -384,13 +393,22 @@ model_vacamole_r <- function(population,
   checkmate::assert_number(mort_reduction_vax, lower = 0, upper = 1)
 
   # all intervention sub-classes pass check for intervention superclass
-  checkmate::assert_list(intervention, types = "intervention", null.ok = TRUE)
+  checkmate::assert_list(
+    intervention,
+    types = "intervention", null.ok = TRUE,
+    names = "unique", any.missing = FALSE
+  )
+  # specifics of vaccination doses are checked in dedicated function
   checkmate::assert_class(vaccination, "vaccination", null.ok = TRUE)
 
   # check that time-dependence functions are passed as a list with at least the
   # arguments `time` and `x`
   # time must be before x, and they must be first two args
-  checkmate::assert_list(time_dependence, "function", null.ok = TRUE)
+  checkmate::assert_list(
+    time_dependence, "function",
+    null.ok = TRUE,
+    names = "unique", any.missing = FALSE
+  )
   # lapply on null returns an empty list
   invisible(
     lapply(time_dependence, checkmate::assert_function,

--- a/R/model_vacamole.R
+++ b/R/model_vacamole.R
@@ -7,7 +7,7 @@
 #' developed at RIVM, the National Institute for Public Health and the
 #' Environment in the Netherlands.
 #' This model is aimed at estimating the impact of 'leaky' vaccination on an
-#' epidemic. See **Details** for more information.
+#' epidemic. See **Details** and **References** for more information.
 #'
 #' @inheritParams model_default
 #' @param hospitalisation_rate A single number for the hospitalisation rate of
@@ -28,6 +28,7 @@
 #' epidemic, with a start and end time, and age-specific vaccination rates for
 #' each dose. See [vaccination()].
 #' @details
+#'
 #' This model allows for:
 #'
 #'  1. A 'hospitalised' compartment along with a hospitalisation rates;
@@ -40,26 +41,15 @@
 #' ## R and Rcpp implementations
 #'
 #' `model_vacamole_cpp()` is a wrapper function for
-#' [.model_vacamole_cpp()], a C++ function that uses Boost _odeint_ solvers
-#' to implement the RIVM Vacamole model.
-#'
-#' `model_vacamole_r()` is a wrapper around the internal function
-#' `.ode_model_vacamole()`, which is passed to [deSolve::lsoda()].
-#'
+#' [.model_vacamole_cpp()], an internal C++ function that uses Boost _odeint_
+#' solvers, while `model_vacamole_r()` is a wrapper around [deSolve::lsoda()]
+#' which takes the the internal function ``.ode_model_vacamole()`.
 #' Both models return equivalent results, but the C++ implementation is faster.
-#'
-#' `.model_vacamole_cpp()` and `.ode_model_vacamole()` both accept
-#' arguments that are created by processing the `population`, `infection`,
-#' `intervention` and `vaccination` arguments to the wrapper function into
-#' simpler forms.
 #'
 #' ## Model parameters
 #'
 #' This model only allows for single, population-wide rates of
-#' transition between the 'susceptible' and 'exposed' compartments, between the
-#' 'exposed' and 'infectious' compartments, and in the recovery rate.
-#'
-#' The default values are:
+#' transitions between compartments. The default values are:
 #'
 #' - Transmissibility (\eqn{\beta}, `transmissibility`): 0.186, resulting from
 #' an \eqn{R_0} = 1.3 and an infectious period of 7 days.
@@ -89,22 +79,7 @@
 #' assuming a 20% reduction in mortality for individuals who are doubly
 #' vaccinated.
 #'
-#' ## Rate interventions and time-dependence
-#'
-#' This model allows interventions on only the primary model rates:
-#' transmissibility, infectiousness rate, hospitalisation rate, mortality rate,
-#' and the recovery rate. Interventions on the secondary model rates calculated
-#' as vaccination-linked modifications of these rates cannot be targeted by rate
-#' interventions or time dependence.
-#'
-#' See the vignette on rate interventions to represent pharmaceutical
-#' interventions (\code{vignette("rate_interventions", package = "epidemics")})
-#' and the vignette on time dependence
-#' (\code{vignette("time_dependence", package = "epidemics")})
-#' for worked out examples on how to
-#' implement these features.
-#'
-#' @return A `data.table` with the columns "time", "compartment", "age_group",
+#' @return A `data.frame` with the columns "time", "compartment", "age_group",
 #' "value". The compartments correspond to the compartments of the model
 #' chosen with `model`.
 #' The current default model has the compartments "susceptible",

--- a/inst/include/epidemic_default.h
+++ b/inst/include/epidemic_default.h
@@ -24,7 +24,7 @@ namespace epidemics {
 
 /// @brief Struct containing the default epidemic ODE system
 struct epidemic_default {
-  // two maps for the infection parameters, one for dynamic modification
+  // two maps for the model parameters, one for dynamic modification
   const std::unordered_map<std::string, double> model_params;
   std::unordered_map<std::string, double> model_params_temp;
   const Eigen::MatrixXd contact_matrix;
@@ -41,7 +41,7 @@ struct epidemic_default {
 
   /// @brief Constructor for the default epidemic struct
   /// @param model_params An unordered map of string-double pairs, with the
-  /// infection parameters as keys, and parameter values as values. The
+  /// model parameters as keys, and parameter values as values. The
   /// model parameters are:
   /// - transmissibility The transmission rate
   /// - infectiousness_rate The rate at which individuals become infectious

--- a/inst/include/epidemic_vacamole.h
+++ b/inst/include/epidemic_vacamole.h
@@ -33,7 +33,7 @@ namespace epidemics {
 
 /// @brief Struct containing the Vacamole epidemic ODE system
 struct epidemic_vacamole {
-  // two maps for the infection parameters, one for dynamic modification
+  // two maps for the model parameters, one for dynamic modification
   const std::unordered_map<std::string, double> model_params;
   std::unordered_map<std::string, double> model_params_temp;
   const Eigen::MatrixXd contact_matrix;
@@ -50,7 +50,7 @@ struct epidemic_vacamole {
 
   /// @brief Constructor for the Vacamole epidemic struct
   /// @param model_params An unordered map of string-double pairs, with the
-  /// infection parameters as keys, and parameter values as values. The
+  /// model parameters as keys, and parameter values as values. The
   /// model parameters are:
   /// - transmissibility The transmission rate for un-or-single vaccinated
   /// individuals

--- a/inst/include/time_dependence.h
+++ b/inst/include/time_dependence.h
@@ -14,7 +14,7 @@ namespace time_dependence {
 /// @brief Apply time-dependence functions to model parameters
 /// @param t The time; this argument is passed to the functions in
 /// `time_dependence`
-/// @param model_params The infection parameters as key-value pairs
+/// @param model_params The model parameters as key-value pairs
 /// @param time_dependence The time-dependence functions as a list of
 /// Rcpp functions whose first argument is time, and whose second argument is
 /// the parameter.

--- a/man/assert_intervention.Rd
+++ b/man/assert_intervention.Rd
@@ -4,7 +4,7 @@
 \alias{assert_intervention}
 \title{Assert properties of a \code{intervention} object}
 \usage{
-assert_intervention(x, type = c("contacts", "rate"), population)
+assert_intervention(x, type = c("contacts", "rate"), population = NULL)
 }
 \arguments{
 \item{x}{A \link{intervention} object.}
@@ -18,7 +18,8 @@ corresponding values of \code{reduction} for each demographic group in
 \code{population}.}
 }
 \value{
-Silently returns the \code{intervention} object \code{x}.
+Silently returns the \verb{<intervention>}-superclass object \code{x} of the
+same class as \code{x}, i.e., \verb{<rate_intervention>} or \verb{<contacts_intervention>}.
 Primarily called for its side effects of throwing errors when \code{x} does not
 meet certain requirements.
 }

--- a/man/assert_population.Rd
+++ b/man/assert_population.Rd
@@ -4,17 +4,20 @@
 \alias{assert_population}
 \title{Assert properties of a \code{population} object}
 \usage{
-assert_population(x, demography_groups = NULL, compartments)
+assert_population(x, compartments, demography_vector = NULL)
 }
 \arguments{
-\item{x}{A \link{population} object.}
+\item{x}{A \verb{<population>} object.}
 
 \item{compartments}{A character vector giving the names of model compartments
 whose length is taken as the reference for the number of columns in the
 \code{initial_conditions} matrix in \code{x}.}
+
+\item{demography_vector}{An optional numeric vector whose length is used to
+check the length of the demography vector present in \code{x}.}
 }
 \value{
-Silently returns the \code{population} object \code{x}.
+Silently returns the \verb{<population>} object \code{x}.
 Primarily called for its side effects of throwing errors when \code{x} does not
 meet certain requirements.
 }

--- a/man/assert_vaccination.Rd
+++ b/man/assert_vaccination.Rd
@@ -4,19 +4,19 @@
 \alias{assert_vaccination}
 \title{Assert properties of a \code{vaccination} object}
 \usage{
-assert_vaccination(x, doses, population)
+assert_vaccination(x, doses, population = NULL)
 }
 \arguments{
 \item{x}{A \link{vaccination} object.}
 
 \item{doses}{The number of doses expected in the vaccination object.}
 
-\item{population}{An optional argument which is a \link{population} object.
+\item{population}{An optional argument which is a \verb{<population>} object.
 When present, this is used to check whether the vaccination object \code{x} has
 corresponding values for each demographic group in \code{population}.}
 }
 \value{
-Silently returns the \code{vaccination} object \code{x}.
+Silently returns the \verb{<vaccination>} object \code{x}.
 Primarily called for its side effects of throwing errors when \code{x} does not
 meet certain requirements.
 }

--- a/man/check_prepare_default_args.Rd
+++ b/man/check_prepare_default_args.Rd
@@ -12,9 +12,8 @@
 }
 \value{
 \code{.check_args_model_default()} invisibly returns the model arguments passed
-in \code{mod_args}. If the model arguments did not previously contain elements
-named \code{intervention} and \code{vaccination}, these are added as dummy objects of
-the corresponding classes.
+in \code{mod_args}. Model functionalities, such as vaccination or interventions,
+passed as \code{NULL} are replaced with dummy values for internal functions.
 
 \code{.prepare_args_model_default()} returns a list of model arguments suitable
 for \code{\link[=.model_default_cpp]{.model_default_cpp()}}. This is a named list consisting of:
@@ -41,9 +40,6 @@ is incremented.
 \description{
 Check and prepare the four main arguments to
 \code{\link[=model_default_cpp]{model_default_cpp()}} for use with \code{\link[=.model_default_cpp]{.model_default_cpp()}}.
-
-\code{.check_args_model_default()} adds an empty \verb{<intervention>} and
-\verb{<vaccination>} object if these are missing from the model arguments.
 }
 \details{
 \code{.prepare_args_model_default()} prepares arguments for

--- a/man/check_prepare_vacamole_args.Rd
+++ b/man/check_prepare_vacamole_args.Rd
@@ -11,10 +11,9 @@
 .prepare_args_model_vacamole(mod_args)
 }
 \value{
-\code{.check_args_model_vacamole()} invisibly returns the model arguments
-passed in \code{mod_args}. If the model arguments did not previously contain
-elements named \code{intervention} this is added as dummy objects of the
-corresponding classes.
+\code{.check_args_model_vacamole()} invisibly returns the model arguments passed
+in \code{mod_args}. Model functionalities, such as interventions,
+passed as \code{NULL} are replaced with dummy values for internal functions.
 
 \code{.prepare_args_model_vacamole()} returns a list of model arguments
 suitable for \code{\link[=.model_vacamole_cpp]{.model_vacamole_cpp()}}. This is a named list consisting of:
@@ -52,9 +51,6 @@ is incremented.
 \description{
 Check and prepare the four main arguments to
 \code{\link[=model_vacamole_cpp]{model_vacamole_cpp()}} for use with \code{\link[=.model_vacamole_cpp]{.model_vacamole_cpp()}}.
-
-\code{.check_args_model_vacamole()} adds an empty \verb{<intervention>} object if
-this is missing from the model arguments.
 }
 \details{
 \code{.prepare_args_model_vacamole()} prepares arguments for

--- a/man/epidemic_size.Rd
+++ b/man/epidemic_size.Rd
@@ -4,10 +4,10 @@
 \alias{epidemic_size}
 \title{Get the epidemic size}
 \usage{
-epidemic_size(data, stage = 1, by_group = TRUE, deaths = TRUE)
+epidemic_size(data, stage = 1, by_group = TRUE, include_deaths = TRUE)
 }
 \arguments{
-\item{data}{A \code{data.table} (or \code{data.frame}) of model output, typically
+\item{data}{A \verb{<data.frame>} of model output, typically
 the output of \code{\link[=model_default_cpp]{model_default_cpp()}} or similar functions.}
 
 \item{stage}{The stage of the epidemic at which to return the epidemic size;
@@ -18,16 +18,19 @@ epidemic.}
 
 \item{by_group}{A logical representing whether the epidemic size should be
 returned by demographic group, or whether a single population-wide value is
-returned.}
+returned. Defaults to \code{TRUE}.}
 
-\item{deaths}{A logical value that indicates whether to count individuals in
-the epidemic size calculation. Setting \code{deaths = TRUE} looks for a \code{"dead"}
-compartment in the data. If there is no such column, the function returns
-only the final number of recovered individuals in each demographic group.}
+\item{include_deaths}{A logical value that indicates whether to count dead
+individuals in the epidemic size calculation.
+Defaults to \code{TRUE}, which makes the function look for a \code{"dead"} compartment
+in the data. If there is no such column, the function returns
+only the final number of recovered or removed individuals in each demographic
+group.}
 }
 \value{
 A single number when \code{by_group = FALSE}, or a vector of numbers of
 the same length as the number of demographic groups when \code{by_group = TRUE}.
+Returns the absolute sizes and not proportions.
 }
 \description{
 Get the size of the epidemic at any stage between the start and the end.

--- a/man/intervention_on_rates.Rd
+++ b/man/intervention_on_rates.Rd
@@ -16,7 +16,7 @@ simulation.}
 
 \item{parameters}{A named list of numeric parameters affected by
 \code{interventions}.
-This represents the infection parameters, such as the transmission rate,
+This represents the model parameters, such as the transmission rate,
 \eqn{\beta}, or the recovery rate, \eqn{\gamma}.}
 }
 \value{

--- a/man/model_default.Rd
+++ b/man/model_default.Rd
@@ -50,24 +50,22 @@ population.}
 from the infectious to the recovered compartment. Often denoted as
 \eqn{\gamma}, with \eqn{\gamma = 1.0 / \text{infectious period}}.}
 
-\item{intervention}{An \verb{<intervention>} object representing an optional
-non-pharmaceutical intervention applied to the population during the
-epidemic. See \code{\link[=intervention]{intervention()}} for details on constructing interventions with
-age-specific effects on social contacts, as well as for guidance on how to
-concatenate multiple overlapping interventions into a single \verb{<intervention>}
-object.}
+\item{intervention}{A named list of \verb{<intervention>}s representing optional
+non-pharmaceutical or pharmaceutical interventions applied during the
+epidemic. Only a single intervention on social contacts of the class
+\verb{<contacts_intervention>} is allowed as the named element "contacts".
+Multiple \verb{<rate_interventions>} on the model parameters are allowed; see
+\strong{Details} for the model parameters for which interventions are supported.}
 
 \item{vaccination}{A \verb{<vaccination>} object representing an optional
 vaccination regime with a single dose, followed during the course of the
-epidemic, with a start and end time, and age-specific vaccination rates.
-See \code{\link[=vaccination]{vaccination()}}.}
+epidemic, with a start and end time, and age-specific vaccination rates.}
 
-\item{time_dependence}{A named list where each name
-is a model parameter, and each element is a function with
-the first two arguments being the current simulation \code{time}, and \code{x}, a value
-that is dependent on \code{time} (\code{x} represents a model parameter).
-See \strong{Details} for more information, as well as the vignette on time-
-dependence \code{vignette("time_dependence", package = "epidemics")}.}
+\item{time_dependence}{A named list of functions that modify model parameters
+as a function of model time. List element names must correspond to model
+parameter names. List elements must be functions of the form
+\verb{function(time, x, ...)}, where \code{time} is the simulation \code{time} and \code{x}
+represents a model parameter. The order of function arguments is important.}
 
 \item{time_end}{The maximum number of timesteps over which to run the model.
 Taken as days, with a default value of 200 days.}
@@ -76,7 +74,7 @@ Taken as days, with a default value of 200 days.}
 default value of 1 day.}
 }
 \value{
-A \code{data.table} with the columns "time", "compartment", "age_group",
+A \code{data.frame} with the columns "time", "compartment", "age_group",
 "value". The compartments correspond to the compartments of the model
 chosen with \code{model}.
 The current default model has the compartments "susceptible", "exposed",
@@ -99,46 +97,25 @@ See \strong{Details} for more information.
 \details{
 \subsection{R and Rcpp implementations}{
 
-\code{model_default_cpp()} is a wrapper function for \code{\link[=.model_default_cpp]{.model_default_cpp()}},
-an internal C++ function that uses Boost \emph{odeint} solvers for an SEIR-V model
-.
-\code{\link[=.model_default_cpp]{.model_default_cpp()}} accepts arguments that
-are created by processing the \code{population}, \code{infection}, \code{intervention} and
-\code{vaccination} arguments to the wrapper function into simpler forms.
-
-\code{model_default_r()} is a wrapper around the internal function
-\code{.ode_model_default()}, which is passed to \code{\link[deSolve:lsoda]{deSolve::lsoda()}}.
-
+\code{model_default_cpp()} is a wrapper function for the internal C++ function
+\code{\link[=.model_default_cpp]{.model_default_cpp()}} that uses Boost \emph{odeint} solvers, while
+\code{model_default_r()} is a wrapper around \code{\link[deSolve:lsoda]{deSolve::lsoda()}} which an R-only
+implementation of the ODE system in \code{.ode_model_default()}.
 Both models return equivalent results, but the C++ implementation is faster.
 }
 
 \subsection{Model parameters}{
 
 This model only allows for single, population-wide rates of
-transition between the 'susceptible' and 'exposed' compartments, between the
-'exposed' and 'infectious' compartments, and in the recovery rate.
-
-The default values are:
+transitions between compartments. The default values are:
 \itemize{
-\item Transmissibility (\eqn{\beta}, \code{transmissibility}): 0.186, resulting from
-an \eqn{R_0} = 1.3 and an infectious period of 7 days.
+\item Transmissibility (\eqn{\beta}, \code{transmissibility}): 0.186, assuming an
+\eqn{R_0} = 1.3 and an infectious period of 7 days.
 \item Infectiousness rate (\eqn{\sigma}, \code{infectiousness_rate}): 0.5, assuming
 a pre-infectious period of 2 days.
 \item Recovery rate (\eqn{\gamma}, \code{recovery_rate}): 0.143, assuming an
 infectious period of 7 days.
 }
-}
-
-\subsection{Implementing time-dependent parameters}{
-
-Model rates or parameters can be made time-dependent by passing a function
-which modifies the parameter based on the current ODE simulation time.
-For example, a function that modifies the transmission rate
-\code{transmissibility} could be passed as
-\code{time_dependence = list(transmissibility = function(time, x) x * time)}.
-This functionality may be used to model events that are expected to have some
-effect on model parameters, such as seasonality or annual schedules such as
-holidays.
 }
 }
 \examples{

--- a/man/model_ebola.Rd
+++ b/man/model_ebola.Rd
@@ -68,14 +68,12 @@ funeral transmission is equivalent to transmission in the community.
 \code{funeral_risk} is used to scale the value of transmissibility for the
 transmissibility \eqn{\beta}. Defaults to 0.5.}
 
-\item{intervention}{An optional \verb{<rate_intervention>} object representing
-pharmaceutical or non-pharmaceutical interventions applied to the infection's
-parameters, such as the transmission rate, over the epidemic.
-See \code{\link[=intervention]{intervention()}} for details on constructing rate interventions.
-Defaults to \code{NULL}, representing no interventions on model parameters.}
+\item{intervention}{A named list of \verb{<rate_intervention>} objects
+representing optional pharmaceutical or non-pharmaceutical interventions
+applied to the model parameters listed above.}
 
 \item{time_dependence}{A named list where each name
-is a model parameter (see \code{infection}), and each element is a function with
+is a model parameter, and each element is a function with
 the first two arguments being the current simulation \code{time}, and \code{x}, a value
 that is dependent on \code{time} (\code{x} represents a model parameter).
 See \strong{Details} for more information, as well as the vignette on time-
@@ -148,8 +146,7 @@ before exiting the infectious compartment will exit the hospitalised
 compartment in the same time.
 
 Hospitalised individuals can contribute to transmission of Ebola to
-susceptibles depending on the value of \code{etu_risk} passed as part of the
-\code{infection} argument, which scales the
+susceptibles depending on the value of \code{etu_risk} which scales the
 baseline transmission rate \eqn{\beta} for hospitalised individuals.
 
 We assume that deaths in hospital lead to Ebola-safe funerals, and

--- a/man/model_vacamole.Rd
+++ b/man/model_vacamole.Rd
@@ -78,24 +78,23 @@ have received two doses of the vaccine.}
 giving the reduction in mortality of infectious and hospitalised individuals
 who have received two doses of the vaccine.}
 
-\item{intervention}{An \verb{<intervention>} object representing an optional
-non-pharmaceutical intervention applied to the population during the
-epidemic. See \code{\link[=intervention]{intervention()}} for details on constructing interventions with
-age-specific effects on social contacts, as well as for guidance on how to
-concatenate multiple overlapping interventions into a single \verb{<intervention>}
-object.}
+\item{intervention}{A named list of \verb{<intervention>}s representing optional
+non-pharmaceutical or pharmaceutical interventions applied during the
+epidemic. Only a single intervention on social contacts of the class
+\verb{<contacts_intervention>} is allowed as the named element "contacts".
+Multiple \verb{<rate_interventions>} on the model parameters are allowed; see
+\strong{Details} for the model parameters for which interventions are supported.}
 
 \item{vaccination}{A \verb{<vaccination>} object representing a
 vaccination regime with \strong{two doses} followed during the course of the
 epidemic, with a start and end time, and age-specific vaccination rates for
 each dose. See \code{\link[=vaccination]{vaccination()}}.}
 
-\item{time_dependence}{A named list where each name
-is a model parameter, and each element is a function with
-the first two arguments being the current simulation \code{time}, and \code{x}, a value
-that is dependent on \code{time} (\code{x} represents a model parameter).
-See \strong{Details} for more information, as well as the vignette on time-
-dependence \code{vignette("time_dependence", package = "epidemics")}.}
+\item{time_dependence}{A named list of functions that modify model parameters
+as a function of model time. List element names must correspond to model
+parameter names. List elements must be functions of the form
+\verb{function(time, x, ...)}, where \code{time} is the simulation \code{time} and \code{x}
+represents a model parameter. The order of function arguments is important.}
 
 \item{time_end}{The maximum number of timesteps over which to run the model.
 Taken as days, with a default value of 200 days.}
@@ -104,7 +103,7 @@ Taken as days, with a default value of 200 days.}
 default value of 1 day.}
 }
 \value{
-A \code{data.table} with the columns "time", "compartment", "age_group",
+A \code{data.frame} with the columns "time", "compartment", "age_group",
 "value". The compartments correspond to the compartments of the model
 chosen with \code{model}.
 The current default model has the compartments "susceptible",
@@ -117,7 +116,7 @@ Simulate an epidemic using the \emph{Vacamole} model for Covid-19
 developed at RIVM, the National Institute for Public Health and the
 Environment in the Netherlands.
 This model is aimed at estimating the impact of 'leaky' vaccination on an
-epidemic. See \strong{Details} for more information.
+epidemic. See \strong{Details} and \strong{References} for more information.
 }
 \details{
 This model allows for:
@@ -131,27 +130,16 @@ such as 'hospitalised' or 'dead'.
 \subsection{R and Rcpp implementations}{
 
 \code{model_vacamole_cpp()} is a wrapper function for
-\code{\link[=.model_vacamole_cpp]{.model_vacamole_cpp()}}, a C++ function that uses Boost \emph{odeint} solvers
-to implement the RIVM Vacamole model.
-
-\code{model_vacamole_r()} is a wrapper around the internal function
-\code{.ode_model_vacamole()}, which is passed to \code{\link[deSolve:lsoda]{deSolve::lsoda()}}.
-
+\code{\link[=.model_vacamole_cpp]{.model_vacamole_cpp()}}, an internal C++ function that uses Boost \emph{odeint}
+solvers, while \code{model_vacamole_r()} is a wrapper around \code{\link[deSolve:lsoda]{deSolve::lsoda()}}
+which takes the the internal function ``.ode_model_vacamole()`.
 Both models return equivalent results, but the C++ implementation is faster.
-
-\code{.model_vacamole_cpp()} and \code{.ode_model_vacamole()} both accept
-arguments that are created by processing the \code{population}, \code{infection},
-\code{intervention} and \code{vaccination} arguments to the wrapper function into
-simpler forms.
 }
 
 \subsection{Model parameters}{
 
 This model only allows for single, population-wide rates of
-transition between the 'susceptible' and 'exposed' compartments, between the
-'exposed' and 'infectious' compartments, and in the recovery rate.
-
-The default values are:
+transitions between compartments. The default values are:
 \itemize{
 \item Transmissibility (\eqn{\beta}, \code{transmissibility}): 0.186, resulting from
 an \eqn{R_0} = 1.3 and an infectious period of 7 days.
@@ -174,22 +162,6 @@ vaccinated.
 assuming a 20\% reduction in mortality for individuals who are doubly
 vaccinated.
 }
-}
-
-\subsection{Rate interventions and time-dependence}{
-
-This model allows interventions on only the primary model rates:
-transmissibility, infectiousness rate, hospitalisation rate, mortality rate,
-and the recovery rate. Interventions on the secondary model rates calculated
-as vaccination-linked modifications of these rates cannot be targeted by rate
-interventions or time dependence.
-
-See the vignette on rate interventions to represent pharmaceutical
-interventions (\code{vignette("rate_interventions", package = "epidemics")})
-and the vignette on time dependence
-(\code{vignette("time_dependence", package = "epidemics")})
-for worked out examples on how to
-implement these features.
 }
 }
 \examples{

--- a/man/new_infections.Rd
+++ b/man/new_infections.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/helpers.R
 \name{new_infections}
 \alias{new_infections}
-\title{Get new infections}
+\title{Get new infections over model time}
 \usage{
-new_infections(data, compartments_from_susceptible, by_group = TRUE)
+new_infections(data, compartments_from_susceptible = NULL, by_group = TRUE)
 }
 \arguments{
-\item{data}{A \code{data.table} (or \code{data.frame}) of model output, typically
+\item{data}{A \verb{<data.frame>} of model output, typically
 the output of \code{\link[=model_default_cpp]{model_default_cpp()}} or similar functions.}
 
 \item{compartments_from_susceptible}{An optional argument, for a character
@@ -21,12 +21,12 @@ returned by demographic group, or whether a single population-wide value is
 returned.}
 }
 \value{
-A \code{data.table} with the same columns as \code{data}, but with the
+A \verb{<data.frame>} with the same columns as \code{data}, but with the
 additional variable under \code{compartment}, "new_infections", resulting in
 additional rows.
 }
 \description{
-Get new infections
+Get new infections over model time
 }
 \examples{
 # create a population

--- a/man/output_to_df.Rd
+++ b/man/output_to_df.Rd
@@ -12,14 +12,14 @@ epidemic) models, with the names "x" and "time", where "x" represents the
 condition of each compartment at each timestep in "time".}
 
 \item{population}{A \verb{<population>} object corresponding to the population
-used in the epidemic model; see \code{\link[=population]{population()}}.
+used in the epidemic model.
 The \verb{<population>} object is used to generate the names of the demographic
 groups, if these are named.}
 
 \item{compartments}{A vector for the model compartment names.}
 }
 \value{
-A \code{data.table} with the columns "compartment", "demography_group",
+A \verb{<data.frame>} with the columns "compartment", "demography_group",
 "value", and "time"; these specify the epidemiological compartment, the
 name of the demography group, the number of individuals of that group in the
 compartment, and the model timestep, respectively.

--- a/src/epidemic.cpp
+++ b/src/epidemic.cpp
@@ -58,8 +58,8 @@ Rcpp::List model_default_cpp_internal(
   // initial conditions from input
   odetools::state_type x = initial_state;
 
-  // create a map of the infection parameters
-  std::unordered_map<std::string, double> infection_params{
+  // create a map of the model parameters
+  std::unordered_map<std::string, double> model_params{
       {"transmissibility", transmissibility},
       {"infectiousness_rate", infectiousness_rate},
       {"recovery_rate", recovery_rate}};
@@ -71,7 +71,7 @@ Rcpp::List model_default_cpp_internal(
 
   // create a default epidemic with parameters
   epidemics::epidemic_default this_model(
-      infection_params, contact_matrix, npi_time_begin, npi_time_end, npi_cr,
+      model_params, contact_matrix, npi_time_begin, npi_time_end, npi_cr,
       vax_time_begin, vax_time_end, vax_nu, rate_interventions_cpp,
       time_dependence);
 

--- a/src/epidemic_vacamole.cpp
+++ b/src/epidemic_vacamole.cpp
@@ -79,12 +79,9 @@ Rcpp::List model_vacamole_cpp_internal(
   // create a map of the model parameters
   std::unordered_map<std::string, double> model_params{
       {"transmissibility", transmissibility},
-      {"transmissibility_vax", transmissibility_vax},
       {"infectiousness_rate", infectiousness_rate},
       {"mortality_rate", mortality_rate},
-      {"mortality_rate_vax", mortality_rate_vax},
       {"hospitalisation_rate", hospitalisation_rate},
-      {"hospitalisation_rate_vax", hospitalisation_rate_vax},
       {"recovery_rate", recovery_rate}};
 
   // create a map of the rate interventions

--- a/src/epidemic_vacamole.cpp
+++ b/src/epidemic_vacamole.cpp
@@ -76,8 +76,8 @@ Rcpp::List model_vacamole_cpp_internal(
   // initial conditions from input
   odetools::state_type x = initial_state;
 
-  // create a map of the infection parameters
-  std::unordered_map<std::string, double> infection_params{
+  // create a map of the model parameters
+  std::unordered_map<std::string, double> model_params{
       {"transmissibility", transmissibility},
       {"transmissibility_vax", transmissibility_vax},
       {"infectiousness_rate", infectiousness_rate},
@@ -94,7 +94,7 @@ Rcpp::List model_vacamole_cpp_internal(
 
   // create a default epidemic with parameters
   epidemics::epidemic_vacamole this_model(
-      infection_params, contact_matrix, npi_time_begin, npi_time_end, npi_cr,
+      model_params, contact_matrix, npi_time_begin, npi_time_end, npi_cr,
       vax_time_begin, vax_time_end, vax_nu, rate_interventions_cpp,
       time_dependence);
 

--- a/tests/testthat/_snaps/ebola_model.md
+++ b/tests/testthat/_snaps/ebola_model.md
@@ -3,11 +3,11 @@
     Code
       head(data)
     Output
-         time demography_group  compartment value
-      1:    1     demo_group_1  susceptible 66933
-      2:    1     demo_group_1      exposed    34
-      3:    1     demo_group_1   infectious    34
-      4:    1     demo_group_1 hospitalised     0
-      5:    1     demo_group_1      funeral     0
-      6:    1     demo_group_1      removed     0
+        time demography_group  compartment value
+      1    1     demo_group_1  susceptible 66933
+      2    1     demo_group_1      exposed    34
+      3    1     demo_group_1   infectious    34
+      4    1     demo_group_1 hospitalised     0
+      5    1     demo_group_1      funeral     0
+      6    1     demo_group_1      removed     0
 

--- a/tests/testthat/test-ebola_model.R
+++ b/tests/testthat/test-ebola_model.R
@@ -29,7 +29,7 @@ test_that("Ebola model: basic expectations", {
     time_end = 200
   )
   expect_s3_class(
-    data, "data.table"
+    data, "data.frame"
   )
   expect_length(data, 4L)
   expect_named(
@@ -142,7 +142,7 @@ test_that("Ebola model works with rate interventions", {
   )
 
   # expect basic outcomes
-  expect_s3_class(data, "data.table")
+  expect_s3_class(data, "data.frame")
   expect_length(data, 4L)
   expect_named(
     data, c("compartment", "demography_group", "value", "time"),

--- a/tests/testthat/test-epidemic_default.R
+++ b/tests/testthat/test-epidemic_default.R
@@ -43,7 +43,7 @@ test_that("Output of default epidemic model Cpp", {
   )
 
   # check for output type and contents
-  expect_s3_class(data, "data.table")
+  expect_s3_class(data, "data.frame")
   expect_length(data, 4L)
   expect_named(
     data, c("compartment", "demography_group", "value", "time"),
@@ -222,7 +222,7 @@ test_that("Output of default epidemic model R", {
   )
 
   # check for output type and contents
-  expect_s3_class(data, "data.table")
+  expect_s3_class(data, "data.frame")
   expect_length(data, 4L)
   expect_named(
     data, c("compartment", "demography_group", "value", "time"),

--- a/tests/testthat/test-epidemic_size.R
+++ b/tests/testthat/test-epidemic_size.R
@@ -63,7 +63,7 @@ test_that("Epidemic size functions", {
   )
 })
 
-#### Test that epidemic size with no deaths is same as deaths = FALSE
+#### Test that epidemic size with no deaths is same as include_deaths = FALSE
 # make initial conditions - order is important
 initial_conditions <- c(
   S = 1 - 1e-6,
@@ -93,7 +93,7 @@ test_that("Epidemic size with no deaths is correct", {
     time_end = 400, increment = 1
   )
   expect_identical(
-    epidemic_size(data, deaths = FALSE),
+    epidemic_size(data, include_deaths = FALSE),
     epidemic_size(data)
   )
 })

--- a/tests/testthat/test-multiple_interventions.R
+++ b/tests/testthat/test-multiple_interventions.R
@@ -93,7 +93,7 @@ test_that("Default model with multiple interventions", {
     time_end = 100
   )
   expect_lte(
-    epidemic_size(data_2_npi, by_group = FALSE, deaths = FALSE),
-    epidemic_size(data_1_npi, by_group = FALSE, deaths = FALSE)
+    epidemic_size(data_2_npi, by_group = FALSE, include_deaths = FALSE),
+    epidemic_size(data_1_npi, by_group = FALSE, include_deaths = FALSE)
   )
 })

--- a/tests/testthat/test-vacamole.R
+++ b/tests/testthat/test-vacamole.R
@@ -68,7 +68,7 @@ test_that("Vacamole model works", {
   )
 
   # expect output is a data.table
-  expect_s3_class(data, "data.table")
+  expect_s3_class(data, "data.frame")
   # expect output has correct compartments
   expect_identical(
     unique(data$compartment),
@@ -120,8 +120,8 @@ test_that("Vacamole model with no vaccination", {
   )
   # test that no individuals are vaccinated in any compartments related to
   # vaccination - e.g. hospitalised-vaccinated etc.
-  pop_vaxxed <- data[time == max(time) &
-    grepl("vaccinated", data$compartment, fixed = TRUE)]$value
+  pop_vaxxed <- data[data$time == max(data$time) &
+    grepl("vaccinated", data$compartment, fixed = TRUE), ]$value
   expect_identical(
     unique(pop_vaxxed), 0.0,
     tolerance = 1e-6
@@ -136,8 +136,8 @@ test_that("Vacamole with non-fatal infection", {
     time_end = 400, increment = 1
   )
   # test that no individuals are dead
-  pop_dead <- data[time == max(time) &
-    grepl("dead", data$compartment, fixed = TRUE)]$value
+  pop_dead <- data[data$time == max(data$time) &
+    grepl("dead", data$compartment, fixed = TRUE), ]$value
   expect_identical(
     unique(pop_dead), 0.0,
     tolerance = 1e-6
@@ -152,8 +152,8 @@ test_that("Vacamole with no hospitalisation", {
     time_end = 400, increment = 1
   )
   # test that no individuals are dead
-  pop_hospitalised <- data[time == max(time) &
-    grepl("hospitalised", data$compartment, fixed = TRUE)]$value
+  pop_hospitalised <- data[data$time == max(data$time) &
+    grepl("hospitalised", data$compartment, fixed = TRUE), ]$value
   expect_identical(
     unique(pop_hospitalised), 0.0,
     tolerance = 1e-6
@@ -215,7 +215,7 @@ test_that("Output of the Vacamole epidemic model R", {
   )
 
   # check for output type and contents
-  expect_s3_class(data, "data.table")
+  expect_s3_class(data, "data.frame")
   expect_length(data, 4L)
   expect_named(
     data, c("compartment", "demography_group", "value", "time"),

--- a/vignettes/ebola_model.Rmd
+++ b/vignettes/ebola_model.Rmd
@@ -243,7 +243,7 @@ Note that the final size here refers to the final size after 365 days, which is 
 # apply the function over each replicate
 data_final_size <- Map(
   data,
-  f = epidemic_size, deaths = FALSE, by_group = FALSE
+  f = epidemic_size, include_deaths = FALSE, by_group = FALSE
 )
 data_final_size <- unlist(data_final_size)
 ```
@@ -445,7 +445,7 @@ improve_hospitalisation <- intervention(
 )
 ```
 
-We can pass the interventions to the model function's `intervention` argument as a named list, with the names indicating the infection parameters to target.
+We can pass the interventions to the model function's `intervention` argument as a named list, with the names indicating the model parameters to target.
 
 ```{r}
 # set a seed for comparison with the baseline model
@@ -689,13 +689,13 @@ A proportion, `1.0 - prop_community`, of infectious individuals are transferred 
 The passage time of individuals in the hospitalised compartment is similar to that of individuals in the infectious compartment (i.e., infectious in the community), which means that an infectious individual with $N$ timesteps before exiting the infectious compartment will exit the hospitalised compartment in the same time.
 
 Hospitalised individuals can contribute to transmission of Ebola to susceptibles depending on the value of $p_\text{ETU}$, which is the probability (or proportion) of hospitalised cases contributing to the infection of susceptibles.
-This is interpreted as the relative safety of Ebolavirus treatment units (ETUs), with a range of 0.0 -- 1.0, where 0.0 indicates that hospitalisation does not reduce transmission at all, while 1.0 indicates that hospitalisation prevents onward transmission entirely.
-This is passed as the `etu_safety` value of the `<infection>`-class object passed to the `infection` argument in `model_ebola_r()`.
+This is interpreted as the relative risk of Ebolavirus treatment units (ETUs), with a range of 0.0 -- 1.0, where 0.0 indicates that hospitalisation prevents onward transmission entirely, while 1.0 indicates that hospitalisation does not reduce transmission at all.
+This is passed as the argument `etu_risk`.
 
 We assume that deaths in hospital lead to Ebola-safe funerals, and individuals exiting the hospitalised compartment move to the 'removed' compartment, which holds both recoveries and deaths.
 
-We assume that infectious individuals who are not hospitalised die, and that deaths outside of hospital lead to funerals that are potentially not Ebola-safe, and the contribution of funerals to Ebola transmission is determined by $p_\text{funeral}$, which can be interpreted as the probability of transmission at a funeral, or the proportion of funerals that are Ebola-safe.
-The relative safety of funerals is passed as the `funeral_safety` value of the `infection` argument.
+We assume that infectious individuals who are not hospitalised die, and that deaths outside of hospital lead to funerals that are potentially not Ebola-safe, and the contribution of funerals to Ebola transmission is determined by $p_\text{funeral}$, which can be interpreted as the relative risk of funerals, and is passed as the `funeral_risk` argument.
+Values closer to 0.0 indicate that there is low to no risk of Ebola transmission at funerals, while values closer to 1.0 indicate that the risk is similar to that of transmission in the community.
 
 Individuals are assumed to spend only a single timestep in the funeral transmission compartment, before they move into the 'removed' compartment. Individuals in the 'removed' compartment do not affect model dynamics.
 

--- a/vignettes/ebola_model.Rmd
+++ b/vignettes/ebola_model.Rmd
@@ -46,7 +46,7 @@ The only rate in the model that can be influenced by an intervention is the tran
 ```{r setup}
 # some initial setup to load necessary packages
 library(epidemics)
-library(data.table)
+library(dplyr)
 library(ggplot2)
 ```
 
@@ -138,14 +138,14 @@ We plot the ebola epidemic over time, showing the number of individuals exposed 
 
 ```{r class.source = 'fold-hide', fig.cap="Model results from a single run showing the number of individuals in the exposed and infectious compartments over 100 days of the outbreak. The model assumes that 1 initially infectious person has exposed 10 others."}
 # plot figure of epidemic curve
-ggplot(
-  data[compartment %in% c("exposed", "infectious"), ],
-  aes(
-    x = time,
-    y = value,
-    colour = compartment
-  )
-) +
+filter(data, compartment %in% c("exposed", "infectious")) %>%
+  ggplot(
+    aes(
+      x = time,
+      y = value,
+      colour = compartment
+    )
+  ) +
   geom_line() +
   scale_y_continuous(
     labels = scales::comma
@@ -179,9 +179,9 @@ We can run the model multiple times --- here, 100 times --- and plot the number 
 set.seed(1)
 
 # run the simulation 100 times
-data <- Map(
-  x = seq(100),
-  f = function(x) {
+data <- lapply(
+  X = seq(100),
+  FUN = function(x) {
     data <- model_ebola_r(
       population = guinea_population,
       time_end = 100
@@ -194,13 +194,14 @@ data <- Map(
 )
 
 # use data.table to collect the data
-data_timeseries <- rbindlist(data)
+data_timeseries <- bind_rows(data)
 ```
 
 We plot the data.
 
 ```{r class.source = 'fold-hide', fig.cap="Model results from 100 runs showing the number of individuals in the infectious compartments over 100 days of each outbreak. All models assume that 1 initially infectious person has exposed 10 others. A simple summary using the mean (black line with standard error as shaded red regions), plotted over the individual model runs (grey) show that there can be wide variation in individual outbreak trajectories."}
-ggplot(data_timeseries[compartment == "infectious", ]) +
+filter(data_timeseries, compartment == "infectious") %>%
+  ggplot() +
   geom_line(
     aes(time, value, group = replicate),
     alpha = 0.3, colour = "grey50"
@@ -241,9 +242,9 @@ Note that the final size here refers to the final size after 365 days, which is 
 
 ```{r}
 # apply the function over each replicate
-data_final_size <- Map(
-  data,
-  f = epidemic_size, include_deaths = FALSE, by_group = FALSE
+data_final_size <- lapply(
+  X = data,
+  FUN = epidemic_size, include_deaths = FALSE, by_group = FALSE
 )
 data_final_size <- unlist(data_final_size)
 ```
@@ -315,11 +316,12 @@ data_baseline$scenario <- "baseline"
 data_intervention$scenario <- "intervention"
 
 # bind the data together
-data_scenarios <- rbindlist(list(data_baseline, data_intervention))
+data_scenarios <- bind_rows(data_baseline, data_intervention)
 ```
 
 ```{r class.source = 'fold-hide', fig.cap="Effect of implementing an intervention that reduces transmission by 30% during an ebola outbreak. The intervention begins on the 15th day (dotted vertical line), and is active for the remainder of the model duration. Applying this intervention leads to many fewer individuals infectious with ebola over the outbreak."}
-ggplot(data_scenarios[compartment == "removed", ]) +
+filter(data_scenarios, compartment == "removed") %>%
+  ggplot() +
   geom_vline(
     xintercept = 15,
     linetype = "dotted"
@@ -390,11 +392,12 @@ data_apply_vax <- model_ebola_r(
 data_apply_vax$scenario <- "apply_vaccination"
 
 # bind the data together
-data_scenarios <- rbindlist(list(data_baseline, data_apply_vax))
+data_scenarios <- bind_rows(data_baseline, data_apply_vax)
 ```
 
 ```{r class.source = 'fold-hide', fig.cap="Effect of implementing a vaccination regime that gradually reduces ebola transmission over time, using the time dependence functionality."}
-ggplot(data_scenarios[compartment == "removed", ]) +
+filter(data_scenarios, compartment == "removed") %>%
+  ggplot() +
   geom_vline(
     xintercept = 15,
     linetype = "dotted"
@@ -464,11 +467,12 @@ data_improve_hosp <- model_ebola_r(
 data_improve_hosp$scenario <- "improve_hosp"
 
 # bind the data together
-data_scenarios <- rbindlist(list(data_baseline, data_improve_hosp))
+data_scenarios <- bind_rows(data_baseline, data_improve_hosp)
 ```
 
 ```{r class.source = 'fold-hide', fig.cap="Effect of implementing an intervention that reduces the proportion of infectious cases in the community by transferring them to a hospitalisation setting."}
-ggplot(data_scenarios[compartment == "removed", ]) +
+filter(data_scenarios, compartment == "removed") %>%
+  ggplot() +
   geom_vline(
     xintercept = 15,
     linetype = "dotted"
@@ -520,11 +524,12 @@ data_improve_etu <- model_ebola_r(
 data_improve_etu$scenario <- "improve_etu"
 
 # bind the data together
-data_scenarios <- rbindlist(list(data_baseline, data_improve_etu))
+data_scenarios <- bind_rows(data_baseline, data_improve_etu)
 ```
 
 ```{r class.source = 'fold-hide', fig.cap="Effect of implementing an intervention that reduces the risk of ebola transmission in a hospitalisation context."}
-ggplot(data_scenarios[compartment == "removed", ]) +
+filter(data_scenarios, compartment == "removed") %>%
+  ggplot() +
   geom_vline(
     xintercept = 15,
     linetype = "dotted"
@@ -579,11 +584,12 @@ data_improve_funeral <- model_ebola_r(
 data_improve_funeral$scenario <- "improve_funeral"
 
 # bind the data together
-data_scenarios <- rbindlist(list(data_baseline, data_improve_funeral))
+data_scenarios <- bind_rows(data_baseline, data_improve_funeral)
 ```
 
 ```{r class.source = 'fold-hide', fig.cap="Effect of implementing an intervention that reduces the risk of ebola transmission in a funeral context."}
-ggplot(data_scenarios[compartment == "removed", ]) +
+filter(data_scenarios, compartment == "removed") %>%
+  ggplot() +
   geom_vline(
     xintercept = 15,
     linetype = "dotted"
@@ -629,13 +635,12 @@ data_combined_interventions <- model_ebola_r(
 data_combined_interventions$scenario <- "combined_interventions"
 
 # bind the data together
-data_scenarios <- rbindlist(
-  list(data_baseline, data_combined_interventions)
-)
+data_scenarios <- bind_rows(data_baseline, data_combined_interventions)
 ```
 
 ```{r class.source = 'fold-hide', fig.cap="Effect of implementing multiple simultaneous interventions to reduce transmission during an ebola outbreak, all beginning on the 15th day (dotted vertical line), and remaining active for the remainder of the model duration. Applying these interventions substantially reduces the final size of the outbreak, with a potential plateau in the outbreak size reached at 100 days."}
-ggplot(data_scenarios[compartment == "removed", ]) +
+filter(data_scenarios, compartment == "removed") %>%
+  ggplot() +
   geom_vline(
     xintercept = 15,
     linetype = "dotted"

--- a/vignettes/epidemics.Rmd
+++ b/vignettes/epidemics.Rmd
@@ -30,7 +30,7 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(epidemics)
-library(data.table)
+library(dplyr)
 library(ggplot2)
 ```
 
@@ -113,15 +113,15 @@ Plot epidemic over time, showing only the number of individuals in the exposed a
 
 ```{r class.source = 'fold-hide'}
 # plot figure of epidemic curve
-ggplot(
-  output[compartment %in% c("exposed", "infectious")],
-  aes(
-    x = time,
-    y = value,
-    col = demography_group,
-    linetype = compartment
-  )
-) +
+filter(output, compartment %in% c("exposed", "infectious")) %>%
+  ggplot(
+    aes(
+      x = time,
+      y = value,
+      col = demography_group,
+      linetype = compartment
+    )
+  ) +
   geom_line() +
   scale_y_continuous(
     labels = scales::comma

--- a/vignettes/finalsize_comparison.Rmd
+++ b/vignettes/finalsize_comparison.Rmd
@@ -83,9 +83,9 @@ While _finalsize_ does not allow for the implementation of a _dynamic_ vaccinati
 
 The two methods are comparable if we model vaccination in _epidemics_ as occurring before the main wave of the epidemic, as this sets up underlying susceptibility.
 
-### Prepare population and infection parameters
+### Prepare population and model parameters
 
-We first prepare the population (modelled on the U.K.), initial conditions, and infection parameters, before passing them to `epidemics::model_default_cpp()`.
+We first prepare the population (modelled on the U.K.), initial conditions, and model parameters, before passing them to `epidemics::model_default_cpp()`.
 This example does not include any interventions or vaccination regimes.
 
 Code to prepare model inputs is folded below for brevity. See the ["Get started"](epidemics.html) vignette for an explanation of how to prepare these inputs.

--- a/vignettes/modelling_interventions.Rmd
+++ b/vignettes/modelling_interventions.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(epidemics)
-library(data.table)
+library(dplyr)
 library(ggplot2)
 ```
 
@@ -114,15 +114,15 @@ Plot epidemic over time, showing only the number of individuals in the exposed a
 
 ```{r class.source = 'fold-hide'}
 # plot figure of epidemic curve
-ggplot(
-  output[compartment %in% c("exposed", "infectious")],
-  aes(
-    x = time,
-    y = value,
-    col = demography_group,
-    linetype = compartment
-  )
-) +
+filter(output, compartment %in% c("exposed", "infectious")) %>%
+  ggplot(
+    aes(
+      x = time,
+      y = value,
+      col = demography_group,
+      linetype = compartment
+    )
+  ) +
   geom_line() +
   annotate(
     geom = "rect",

--- a/vignettes/modelling_vaccination.Rmd
+++ b/vignettes/modelling_vaccination.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(epidemics)
-library(data.table)
+library(dplyr)
 library(ggplot2)
 ```
 
@@ -113,15 +113,15 @@ Plot epidemic over time, showing only the number of individuals in the exposed, 
 
 ```{r class.source = 'fold-hide'}
 # plot figure of epidemic curve
-ggplot(
-  output[compartment %in% c("exposed", "infectious")],
-  aes(
-    x = time,
-    y = value,
-    col = demography_group,
-    linetype = compartment
-  )
-) +
+filter(output, compartment %in% c("exposed", "infectious")) %>%
+  ggplot(
+    aes(
+      x = time,
+      y = value,
+      col = demography_group,
+      linetype = compartment
+    )
+  ) +
   geom_line() +
   scale_y_continuous(
     labels = scales::comma

--- a/vignettes/modelling_vaccination.Rmd
+++ b/vignettes/modelling_vaccination.Rmd
@@ -89,7 +89,7 @@ vaccinate_elders <- vaccination(
   name = "vaccinate elders",
   time_begin = matrix(100, nrow(contact_matrix)),
   time_end = matrix(250, nrow(contact_matrix)),
-  nu = matrix(c(0.0001, 0.0001, 0.0001))
+  nu = matrix(c(0.0001, 0, 0))
 )
 
 # view vaccination object

--- a/vignettes/multiple_interventions.Rmd
+++ b/vignettes/multiple_interventions.Rmd
@@ -32,7 +32,6 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(epidemics)
-library(dplyr)
 library(ggplot2)
 ```
 
@@ -508,4 +507,3 @@ plot_three_interventions
 In this scenario with school closures for 6 months as well as two phases of workplace closures for 2 months each, the epidemic would continue for over 600 days, or more than one and a half years, but the number of days with 10,000 or more daily cases would be reduced, and these typically occur once the interventions on workplaces are lifted --- this is similar to the previous example.
 
 In this scenario, the epidemic is expected to have a final size of around `r scales::comma(epidemic_size(data_combined, by_group = FALSE), accuracy = 1, scale = 1e-6, suffix = " million")` individuals infected overall --- this is lower than the previous examples.
-

--- a/vignettes/multiple_interventions.Rmd
+++ b/vignettes/multiple_interventions.Rmd
@@ -32,7 +32,7 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(epidemics)
-library(data.table)
+library(dplyr)
 library(ggplot2)
 ```
 

--- a/vignettes/rate_interventions.Rmd
+++ b/vignettes/rate_interventions.Rmd
@@ -32,7 +32,7 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(epidemics)
-library(data.table)
+library(dplyr)
 library(ggplot2)
 ```
 
@@ -145,7 +145,7 @@ data$scenario <- "baseline"
 data_masks$scenario <- "masks"
 
 # bind data together
-data_combined <- rbindlist(list(data, data_masks))
+data_combined <- bind_rows(data, data_masks)
 ```
 
 We plot the data to examine the effect that implementing a mask mandate has on the daily number of new infections.

--- a/vignettes/time_dependence.Rmd
+++ b/vignettes/time_dependence.Rmd
@@ -29,8 +29,8 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(epidemics)
+library(dplyr)
 library(ggplot2)
-library(data.table)
 ```
 
 ::: {.alert .alert-warning}
@@ -204,7 +204,7 @@ data_infections$scenario <- "baseline"
 data_infections_npi$scenario <- "intervention"
 
 # combine the data
-data_npi_compare <- rbindlist(list(data_infections, data_infections_npi))
+data_npi_compare <- bind_rows(data_infections, data_infections_npi)
 ```
 
 ```{r class.source = 'fold-hide'}
@@ -289,7 +289,7 @@ data_vax_infections <- new_infections(
 data_vax_infections$scenario <- "vaccination"
 
 # combine data
-data_vax_compare <- rbindlist(list(data_infections, data_vax_infections))
+data_vax_compare <- bind_rows(data_infections, data_vax_infections)
 ```
 
 ```{r class.source = 'fold-hide'}
@@ -302,7 +302,9 @@ ggplot(data_vax_compare) +
     fill = "grey", alpha = 0.1
   ) +
   geom_line(
-    data = data_vax[compartment == "vaccinated" & demography_group == "40+", ],
+    data = filter(
+      data_vax, compartment == "vaccinated" & demography_group == "40+"
+    ),
     aes(time, value / 1e2),
     colour = "darkblue"
   ) +

--- a/vignettes/time_dependence.Rmd
+++ b/vignettes/time_dependence.Rmd
@@ -303,7 +303,7 @@ ggplot(data_vax_compare) +
   ) +
   geom_line(
     data = filter(
-      data_vax, compartment == "vaccinated" & demography_group == "40+"
+      data_vax, compartment == "vaccinated", demography_group == "40+"
     ),
     aes(time, value / 1e2),
     colour = "darkblue"

--- a/vignettes/vacamole.Rmd
+++ b/vignettes/vacamole.Rmd
@@ -218,6 +218,10 @@ data_vaccination <- model_vacamole_cpp(
 First, we calculate the total number of infections resulting in recoveries and deaths over the course of the simulation; this is the epidemic's final size.
 
 ```{r}
+# set data.table
+setDT(data)
+setDT(data_vaccination)
+
 # collect data from the two scenarios
 data_scenarios <- list(data, data_vaccination)
 

--- a/vignettes/vacamole.Rmd
+++ b/vignettes/vacamole.Rmd
@@ -62,7 +62,8 @@ The details of the ODE system for the version of Vacamole included in _epidemics
 
 ```{r setup}
 library(epidemics)
-library(data.table)
+library(dplyr)
+library(tidyr)
 library(ggplot2)
 library(colorspace)
 library(scales)
@@ -218,10 +219,6 @@ data_vaccination <- model_vacamole_cpp(
 First, we calculate the total number of infections resulting in recoveries and deaths over the course of the simulation; this is the epidemic's final size.
 
 ```{r}
-# set data.table
-setDT(data)
-setDT(data_vaccination)
-
 # collect data from the two scenarios
 data_scenarios <- list(data, data_vaccination)
 
@@ -229,10 +226,12 @@ data_scenarios <- list(data, data_vaccination)
 data_scenarios <- Map(
   data_scenarios, c("no_vax", "vax"),
   f = function(df, sc) {
-    df_ <- unique(df[, "demography_group"], by = "demography_group")
+    df_ <- distinct(df, demography_group)
+
     # get total deaths per group
-    df_$total_deaths <- df[df$time == max(df$time) &
-      df$compartment == "dead", ]$value
+    df_$total_deaths <- filter(
+      df, time == max(time) & compartment == "dead"
+    ) %>% pull(value)
 
     # get total recoveries per group using helper function `epidemic_size()`
     # do not count dead
@@ -247,12 +246,13 @@ data_scenarios <- Map(
 )
 
 # collect data
-data_scenarios <- rbindlist(data_scenarios)
+data_scenarios <- bind_rows(data_scenarios)
 
 # transform to long format
-data_scenarios <- melt(
+data_scenarios <- pivot_longer(
   data_scenarios,
-  id.vars = c("demography_group", "scenario")
+  cols = c("total_deaths", "total_recovered"),
+  names_to = "measure"
 )
 ```
 
@@ -264,12 +264,12 @@ ggplot(data_scenarios) +
     colour = "black"
   ) +
   facet_wrap(
-    ~variable,
+    facets = vars(measure),
     scales = "free_y",
     labeller = labeller(
-      variable = c(
+      measure = c(
         total_deaths = "Total deaths",
-        total_recovered = "Epidemic size (infections, not counting deaths)"
+        total_recovered = "Epidemic size (infections without deaths)"
       )
     )
   ) +
@@ -317,17 +317,21 @@ data_scenarios <- list(data, data_vaccination)
 peak_hospital_occupancy <- vapply(data_scenarios, function(df) {
   # get highest hospital occupancy
   # first get total hospitalisations among vaccinated and un- or part-vacc.
-  df <- dcast(
-    df[compartment %like% "hospitalised", ],
-    time + demography_group ~ compartment,
-    value.var = "value"
-  )
-  df[, total_hosp := hospitalised + hospitalised_vaccinated]
-
-  # sum all age groups
-  df <- df[, list(total_hosp = sum(total_hosp)), by = "time"]
-
-  df[total_hosp == max(total_hosp), ]$total_hosp
+  df <- filter(
+    df,
+    grepl(
+      pattern = "hospitalised", x = compartment,
+      fixed = TRUE
+    )
+  ) %>%
+    # summarise all hospitalised over time, aggregating away age groups
+    summarise(
+      total_hosp = sum(value), .by = "time"
+    ) %>%
+    # filter for the time point with highest hospital occupancy
+    filter(total_hosp == max(total_hosp)) %>%
+    # get the value
+    pull(total_hosp)
 }, FUN.VALUE = numeric(1))
 
 # set names for comprehensibility

--- a/vignettes/vacamole.Rmd
+++ b/vignettes/vacamole.Rmd
@@ -230,7 +230,7 @@ data_scenarios <- Map(
 
     # get total deaths per group
     df_$total_deaths <- filter(
-      df, time == max(time) & compartment == "dead"
+      df, time == max(time), compartment == "dead"
     ) %>% pull(value)
 
     # get total recoveries per group using helper function `epidemic_size()`

--- a/vignettes/vacamole.Rmd
+++ b/vignettes/vacamole.Rmd
@@ -227,10 +227,12 @@ data_scenarios <- Map(
   f = function(df, sc) {
     df_ <- unique(df[, "demography_group"], by = "demography_group")
     # get total deaths per group
-    df_$total_deaths <- df[time == max(time) & compartment == "dead", ]$value
+    df_$total_deaths <- df[df$time == max(df$time) &
+      df$compartment == "dead", ]$value
 
     # get total recoveries per group using helper function `epidemic_size()`
-    df_$total_recovered <- epidemic_size(df, deaths = FALSE) # do not count dead
+    # do not count dead
+    df_$total_recovered <- epidemic_size(df, include_deaths = FALSE)
 
     # add scenario information
     df_$scenario <- sc


### PR DESCRIPTION
This PR makes a number of smaller edits to clean up and streamline the existing codebase prior to adding a diphtheria model.

1. All references to infections have been removed unless appropriate, with variables renamed where necessary,
2. All optional model inputs now use {checkmate}'s `null.ok` argument instead of an `if-else` ladder,
3. All model checker functions now check whether optional arguments such as `intervention` are `NULL`, instead of missing (replacing `missing()` with `is.null()`),
4. All model functions' documentation has been updated and compressed where possible,
5. Internal C++ code for Vacamole has been modified to disallow rate interventions on derived parameters, and this is WIP #144,
6. All helper functions now place required args before optional args,
7. Helper functions return `<data.frame>` instead of `<data.table>` to improve interoperability, although {data.table} is still used internally,
8. Helper functions' documentation has been updated,
9. Vignettes have been corrected where required,
10. Tests have been updated to account for data.frame output and renamed function arguments - a snapshot test for ebola has been updated to reflect data.frame output,
11. Fixes #120 by correcting younger age group vaccination rates in vignette.