### PR TITLE
Reduce population validation sensitivity

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -62,7 +62,7 @@ references:
     given-names: Michel
     email: michellang@gmail.com
     orcid: https://orcid.org/0000-0001-9754-0393
-  year: '2023'
+  year: '2024'
 - type: software
   title: cli
   abstract: 'cli: Helpers for Developing Command Line Interfaces'
@@ -73,7 +73,7 @@ references:
   - family-names: Csárdi
     given-names: Gábor
     email: csardi.gabor@gmail.com
-  year: '2023'
+  year: '2024'
 - type: software
   title: data.table
   abstract: 'data.table: Extension of `data.frame`'
@@ -90,7 +90,7 @@ references:
   - family-names: Srinivasan
     given-names: Arun
     email: asrini@pm.me
-  year: '2023'
+  year: '2024'
 - type: software
   title: deSolve
   abstract: 'deSolve: Solvers for Initial Value Problems of Differential Equations
@@ -111,7 +111,7 @@ references:
     given-names: R. Woodrow
     email: setzer.woodrow@epa.gov
     orcid: https://orcid.org/0000-0002-6709-9186
-  year: '2023'
+  year: '2024'
 - type: software
   title: glue
   abstract: 'glue: Interpreted String Literals'
@@ -124,9 +124,9 @@ references:
     orcid: https://orcid.org/0000-0002-2739-7082
   - family-names: Bryan
     given-names: Jennifer
-    email: jenny@rstudio.com
+    email: jenny@posit.co
     orcid: https://orcid.org/0000-0002-6983-2759
-  year: '2023'
+  year: '2024'
 - type: software
   title: Rcpp
   abstract: 'Rcpp: Seamless R and C++ Integration'
@@ -152,7 +152,7 @@ references:
     given-names: Douglas
   - family-names: Chambers
     given-names: John
-  year: '2023'
+  year: '2024'
 - type: software
   title: RcppEigen
   abstract: 'RcppEigen: ''Rcpp'' Integration for the ''Eigen'' Templated Linear Algebra
@@ -169,7 +169,7 @@ references:
     given-names: Romain
   - family-names: Eigen
     given-names: Yixuan Qiu; the authors of Eigen for the included version of
-  year: '2023'
+  year: '2024'
 - type: software
   title: stats
   abstract: 'R: A Language and Environment for Statistical Computing'
@@ -178,7 +178,7 @@ references:
   - name: R Core Team
   location:
     name: Vienna, Austria
-  year: '2023'
+  year: '2024'
   institution:
     name: R Foundation for Statistical Computing
 - type: software
@@ -189,7 +189,7 @@ references:
   - name: R Core Team
   location:
     name: Vienna, Austria
-  year: '2023'
+  year: '2024'
   institution:
     name: R Foundation for Statistical Computing
 - type: software
@@ -204,7 +204,7 @@ references:
   - family-names: Vaughan
     given-names: Davis
     email: davis@posit.co
-  year: '2023'
+  year: '2024'
 - type: software
   title: bookdown
   abstract: 'bookdown: Authoring Books and Technical Documents with R Markdown'
@@ -216,7 +216,7 @@ references:
     given-names: Yihui
     email: xie@yihui.name
     orcid: https://orcid.org/0000-0003-0645-5666
-  year: '2023'
+  year: '2024'
 - type: software
   title: colorspace
   abstract: 'colorspace: A Toolbox for Manipulating and Assessing Colors and Palettes'
@@ -255,7 +255,7 @@ references:
     given-names: Achim
     email: Achim.Zeileis@R-project.org
     orcid: https://orcid.org/0000-0003-0918-3766
-  year: '2023'
+  year: '2024'
 - type: software
   title: dplyr
   abstract: 'dplyr: A Grammar of Data Manipulation'
@@ -279,7 +279,7 @@ references:
     given-names: Davis
     email: davis@posit.co
     orcid: https://orcid.org/0000-0003-4777-038X
-  year: '2023'
+  year: '2024'
 - type: software
   title: EpiEstim
   abstract: 'EpiEstim: Estimate Time Varying Reproduction Numbers from Epidemic Curves'
@@ -291,7 +291,7 @@ references:
     given-names: Anne
     email: a.cori@imperial.ac.uk
     orcid: https://orcid.org/0000-0002-8443-9162
-  year: '2023'
+  year: '2024'
 - type: software
   title: finalsize
   abstract: 'finalsize: Calculate the Final Size of an Epidemic'
@@ -311,7 +311,7 @@ references:
     given-names: Adam
     email: adam.kucharski@lshtm.ac.uk
     orcid: https://orcid.org/0000-0001-8814-9421
-  year: '2023'
+  year: '2024'
 - type: software
   title: ggplot2
   abstract: 'ggplot2: Create Elegant Data Visualisations Using the Grammar of Graphics'
@@ -346,7 +346,7 @@ references:
   - family-names: Dunnington
     given-names: Dewey
     orcid: https://orcid.org/0000-0002-9415-4582
-  year: '2023'
+  year: '2024'
 - type: software
   title: knitr
   abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
@@ -358,7 +358,7 @@ references:
     given-names: Yihui
     email: xie@yihui.name
     orcid: https://orcid.org/0000-0003-0645-5666
-  year: '2023'
+  year: '2024'
 - type: software
   title: rmarkdown
   abstract: 'rmarkdown: Dynamic Documents for R'
@@ -401,7 +401,7 @@ references:
     given-names: Richard
     email: rich@posit.co
     orcid: https://orcid.org/0000-0003-3925-190X
-  year: '2023'
+  year: '2024'
 - type: software
   title: scales
   abstract: 'scales: Scale Functions for Visualization'
@@ -418,7 +418,7 @@ references:
     orcid: https://orcid.org/0000-0002-5147-4711
   - family-names: Seidel
     given-names: Dana
-  year: '2023'
+  year: '2024'
 - type: software
   title: socialmixr
   abstract: 'socialmixr: Social Mixing Matrices for Infectious Disease Modelling'
@@ -433,7 +433,7 @@ references:
     given-names: Lander
   - family-names: Gruson
     given-names: Hugo
-  year: '2023'
+  year: '2024'
 - type: software
   title: spelling
   abstract: 'spelling: Tools for Spell Checking in R'
@@ -448,7 +448,7 @@ references:
   - family-names: Hester
     given-names: Jim
     email: james.hester@rstudio.com
-  year: '2023'
+  year: '2024'
 - type: software
   title: testthat
   abstract: 'testthat: Unit Testing for R'
@@ -459,7 +459,7 @@ references:
   - family-names: Wickham
     given-names: Hadley
     email: hadley@posit.co
-  year: '2023'
+  year: '2024'
   version: '>= 3.0.0'
 - type: software
   title: tibble
@@ -475,7 +475,7 @@ references:
   - family-names: Wickham
     given-names: Hadley
     email: hadley@rstudio.com
-  year: '2023'
+  year: '2024'
 - type: software
   title: tidyr
   abstract: 'tidyr: Tidy Messy Data'
@@ -491,7 +491,7 @@ references:
     email: davis@posit.co
   - family-names: Girlich
     given-names: Maximilian
-  year: '2023'
+  year: '2024'
 - type: software
   title: BH
   abstract: 'BH: Boost C++ Header Files'
@@ -505,4 +505,4 @@ references:
     given-names: John W.
   - family-names: Kane
     given-names: Michael J.
-  year: '2023'
+  year: '2024'

--- a/R/population.R
+++ b/R/population.R
@@ -130,7 +130,7 @@ validate_population <- function(object) {
         nrows = length(object$demography_vector)
       ),
     "`initial_conditions` rows must always sum to 1.0" =
-      (all(abs(rowSums(object$initial_conditions) - 1) < 1e-6))
+      (all(abs(rowSums(object$initial_conditions) - 1.0) < 1e-3))
   )
   invisible(object)
 }


### PR DESCRIPTION
This PR fixes #118 by reducing the sensitivity of the sum of population demographic group proportions to 1e-3 from 1e-6.

Also updates the citation file.