### PR TITLE
Corrections to the Vacamole model

### DIFF
--- a/R/check_args_vacamole.R
+++ b/R/check_args_vacamole.R
@@ -60,10 +60,17 @@
   # prepare the contact matrix and the initial conditions
   cmat_init_state <- .prepare_population(mod_args[["population"]])
 
-  # check the interventions list against the population
+  # check the interventions list against the population and allowed
+  # model parameters
   mod_args[["intervention"]] <- .cross_check_intervention(
     mod_args[["intervention"]], mod_args[["population"]],
-    c("contacts", "transmission_rate", "infectiousness_rate", "recovery_rate")
+    c(
+      "contacts",
+      "transmission_rate", "infectiousness_rate", "recovery_rate",
+      "hospitalisation_rate", "mortality_rate",
+      "transmission_rate_vax", "hospitalisation_rate_vax",
+      "mortality_rate_vax"
+    )
   )
   # check the vaccination against the population
   mod_args[["vaccination"]] <- .cross_check_vaccination(

--- a/R/model_vacamole.R
+++ b/R/model_vacamole.R
@@ -172,9 +172,9 @@ model_vacamole <- function(population,
   checkmate::assert_numeric(recovery_rate, lower = 0, finite = TRUE)
 
   # parameters for rates affecting only doubly vaccinated
-  checkmate::assert_numeric(transmission_rate_vax, lower = 0, upper = 1)
-  checkmate::assert_numeric(hospitalisation_rate_vax, lower = 0, upper = 1)
-  checkmate::assert_numeric(mortality_rate_vax, lower = 0, upper = 1)
+  checkmate::assert_numeric(transmission_rate_vax, lower = 0, finite = TRUE)
+  checkmate::assert_numeric(hospitalisation_rate_vax, lower = 0, finite = TRUE)
+  checkmate::assert_numeric(mortality_rate_vax, lower = 0, finite = TRUE)
 
   # check the time end and increment
   # restrict increment to lower limit of 1e-6
@@ -261,7 +261,12 @@ model_vacamole <- function(population,
   time_dependence <- list(
     .cross_check_timedep(
       time_dependence,
-      c("transmission_rate", "infectiousness_rate", "recovery_rate")
+      c(
+        "transmission_rate", "infectiousness_rate", "recovery_rate",
+        "hospitalisation_rate", "mortality_rate",
+        "transmission_rate_vax", "hospitalisation_rate_vax",
+        "mortality_rate_vax"
+      )
     )
   )
 

--- a/inst/include/model_default.h
+++ b/inst/include/model_default.h
@@ -116,11 +116,12 @@ struct epidemic_default {
     // for vectorised operations
 
     // compartmental transitions without accounting for contacts
-    Eigen::ArrayXd sToE = model_params_temp["transmission_rate"] *
+    Eigen::ArrayXd sToE = model_params_temp.at("transmission_rate") *
                           x.col(0).array() * (cm_temp * x.col(2)).array();
     Eigen::ArrayXd eToI =
-        model_params_temp["infectiousness_rate"] * x.col(1).array();
-    Eigen::ArrayXd iToR = model_params_temp["recovery_rate"] * x.col(2).array();
+        model_params_temp.at("infectiousness_rate") * x.col(1).array();
+    Eigen::ArrayXd iToR =
+        model_params_temp.at("recovery_rate") * x.col(2).array();
     Eigen::ArrayXd sToV = vax_nu_current.col(0).array() * x.col(0).array();
 
     // compartmental changes accounting for contacts (for dS and dE)

--- a/inst/include/model_diphtheria.h
+++ b/inst/include/model_diphtheria.h
@@ -100,21 +100,22 @@ struct epidemic_diphtheria {
     // compartmental transitions without accounting for stratified contacts
     // NOTE: division by population size - this is typically included in the
     // contact matrix scaling in other models
-    Eigen::ArrayXd sToE = model_params_temp["transmission_rate"] *
+    Eigen::ArrayXd sToE = model_params_temp.at("transmission_rate") *
                           total_infections * x.col(0) / x.sum();
     Eigen::ArrayXd eToI =
-        model_params_temp["infectiousness_rate"] * x.col(1).array();
+        model_params_temp.at("infectiousness_rate") * x.col(1).array();
     // hospitalised individuals = a function of reporting, p(hospitalised),
     // time to hospitalisation, and time to discharge from hospital
-    Eigen::ArrayXd iToH =
-        model_params_temp["prop_hosp"] * model_params_temp["reporting_rate"] *
-        model_params_temp["hosp_entry_rate"] * x.col(2).array();
+    Eigen::ArrayXd iToH = model_params_temp.at("prop_hosp") *
+                          model_params_temp.at("reporting_rate") *
+                          model_params_temp.at("hosp_entry_rate") *
+                          x.col(2).array();
 
     // recoveries are from the infectious/ed who are NOT hospitalised
     Eigen::ArrayXd iToR =
-        model_params_temp["recovery_rate"] * (x.col(2).array() - iToH);
+        model_params_temp.at("recovery_rate") * (x.col(2).array() - iToH);
     Eigen::ArrayXd hToR =
-        model_params_temp["hosp_exit_rate"] * x.col(3).array();
+        model_params_temp.at("hosp_exit_rate") * x.col(3).array();
 
     // compartmental changes; note that there are no contacts
     // β: transmission_rate; σ: infectiousness rate; γ: recovery rate

--- a/inst/include/model_vacamole.h
+++ b/inst/include/model_vacamole.h
@@ -138,7 +138,7 @@ struct epidemic_vacamole {
 
     // compartmental transitions without accounting for contacts
     // Susceptible (unvaccinated) to exposed
-    Eigen::ArrayXd sToE = model_params_temp["transmission_rate"] *
+    Eigen::ArrayXd sToE = model_params_temp.at("transmission_rate") *
                           x.col(0).array() *
                           (cm_temp * (x.col(5) + x.col(6))).array();
 
@@ -148,53 +148,55 @@ struct epidemic_vacamole {
     Eigen::ArrayXd v1ToV2 = vax_nu_current.col(1).array() * x.col(1).array();
 
     // Vaccinated one dose to exposed - same as susceptible to exposed
-    Eigen::ArrayXd v1ToE = model_params_temp["transmission_rate"] *
+    Eigen::ArrayXd v1ToE = model_params_temp.at("transmission_rate") *
                            x.col(1).array() *
                            (cm_temp * (x.col(5) + x.col(6))).array();
     // Vaccinated two doses to exposed - uses different transmission_rate
-    Eigen::ArrayXd v2ToEv = model_params_temp["transmission_rate_vax"] *
+    Eigen::ArrayXd v2ToEv = model_params_temp.at("transmission_rate_vax") *
                             x.col(2).array() *
                             (cm_temp * (x.col(5) + x.col(6))).array();
 
     // Exposed unvaccinated or not protected to infectious
     Eigen::ArrayXd eToI =
-        model_params_temp["infectiousness_rate"] * x.col(3).array();
+        model_params_temp.at("infectiousness_rate") * x.col(3).array();
     // Exposed vaccinated to infectious
     Eigen::ArrayXd evToIv =
-        model_params_temp["infectiousness_rate"] * x.col(4).array();
+        model_params_temp.at("infectiousness_rate") * x.col(4).array();
 
     // Infectious to hospitalised
     Eigen::ArrayXd iToH =
-        model_params_temp["hospitalisation_rate"] * x.col(5).array();
+        model_params_temp.at("hospitalisation_rate") * x.col(5).array();
     // Vaccinated infectious to hospitalised
     Eigen::ArrayXd ivToHv =
-        model_params_temp["hospitalisation_rate_vax"] * x.col(6).array();
+        model_params_temp.at("hospitalisation_rate_vax") * x.col(6).array();
 
     // Infectious to dead
     Eigen::ArrayXd iToD =
-        model_params_temp["mortality_rate"] * x.col(5).array();
+        model_params_temp.at("mortality_rate") * x.col(5).array();
     // Infectious vaccinated to dead
     Eigen::ArrayXd ivToD =
-        model_params_temp["mortality_rate_vax"] * x.col(6).array();
+        model_params_temp.at("mortality_rate_vax") * x.col(6).array();
 
     // Hospitalised to dead
     Eigen::ArrayXd hToD =
-        model_params_temp["mortality_rate"] * x.col(7).array();
+        model_params_temp.at("mortality_rate") * x.col(7).array();
     // Hospitalised vaccinated to dead
     Eigen::ArrayXd hvToD =
-        model_params_temp["mortality_rate_vax"] * x.col(8).array();
+        model_params_temp.at("mortality_rate_vax") * x.col(8).array();
 
     // Infectious to recovered
-    Eigen::ArrayXd iToR = model_params_temp["recovery_rate"] * x.col(5).array();
+    Eigen::ArrayXd iToR =
+        model_params_temp.at("recovery_rate") * x.col(5).array();
     // Infectious vaccinated to recovered
     Eigen::ArrayXd ivToR =
-        model_params_temp["recovery_rate"] * x.col(6).array();
+        model_params_temp.at("recovery_rate") * x.col(6).array();
 
     // Hospitalised to recovered
-    Eigen::ArrayXd hToR = model_params_temp["recovery_rate"] * x.col(7).array();
+    Eigen::ArrayXd hToR =
+        model_params_temp.at("recovery_rate") * x.col(7).array();
     // Hospitalised vaccinated to recovered
     Eigen::ArrayXd hvToR =
-        model_params_temp["recovery_rate"] * x.col(8).array();
+        model_params_temp.at("recovery_rate") * x.col(8).array();
 
     // compartmental changes accounting for contacts
     // β: transmission_rate; βv: transmission_rate for doubly vaccinated;

--- a/src/model_vacamole.cpp
+++ b/src/model_vacamole.cpp
@@ -79,9 +79,12 @@ Rcpp::List model_vacamole_internal(
   // create a map of the model parameters
   std::unordered_map<std::string, double> model_params{
       {"transmission_rate", transmission_rate},
+      {"transmission_rate_vax", transmission_rate_vax},
       {"infectiousness_rate", infectiousness_rate},
       {"mortality_rate", mortality_rate},
       {"hospitalisation_rate", hospitalisation_rate},
+      {"mortality_rate_vax", mortality_rate_vax},
+      {"hospitalisation_rate_vax", hospitalisation_rate_vax},
       {"recovery_rate", recovery_rate}};
 
   // create a map of the rate interventions

--- a/tests/testthat/test-model_vacamole.R
+++ b/tests/testthat/test-model_vacamole.R
@@ -199,6 +199,36 @@ test_that("Vacamole model: statistical correctness, parameters", {
     unique(data[grepl("hospitalised", data$compartment, fixed = TRUE)]$value),
     0
   )
+
+  # expect that full vaccination susceptibility (beta_V = 1.0)
+  # removes benefit of vaccination
+  uk_pop_all_vax <- uk_population
+  uk_pop_all_vax$initial_conditions[, "S"] <- rep(0, 2)
+  uk_pop_all_vax$initial_conditions[, "V2"] <- rep((1 - 1e-6), 2)
+
+  # set similar transmisison rate
+  beta <- 1.3 / 7
+  # for normal population with no vaccination, no mortality, no hospitalisation
+  data <- model_vacamole(
+    population = uk_population,
+    transmission_rate = beta,
+    mortality_rate = 0, hospitalisation_rate = 0
+  )
+
+  # for artificial population where all are double vaccinated,
+  # no mortality, no hospitalisation
+  data_all_vax <- model_vacamole(
+    population = uk_pop_all_vax,
+    transmission_rate_vax = beta,
+    mortality_rate = 0, hospitalisation_rate = 0
+  )
+
+  # when vaccination does not reduce transmission,
+  # expect ratio is 1.0, i.e., both are identical
+  expect_identical(
+    epidemic_size(data_all_vax), epidemic_size(data),
+    tolerance = 1e-6
+  )
 })
 
 # prepare baseline for comparison of against intervention scenarios

--- a/tests/testthat/test-model_vacamole.R
+++ b/tests/testthat/test-model_vacamole.R
@@ -283,7 +283,7 @@ test_that("Vacamole model: contacts interventions and stats. correctness", {
   )
 })
 
-test_that("Vacamole model: rate interventions", {
+test_that("Vacamole model: rate interventions and stats correctness", {
   intervention_01 <- intervention(
     "mask_mandate", "rate", 0, time_end, 0.5
   )
@@ -369,6 +369,32 @@ test_that("Vacamole model: time dependence", {
   # expect final size is lower with intervention
   expect_true(
     all(epidemic_size(data_baseline) > epidemic_size(data))
+  )
+
+  # An example with waning immunity
+  # expect that a fully vaccinated population subjected to a 'waning immunity'
+  # time-dependence has a higher final size than one without the intervention
+  uk_pop_all_vax <- uk_population
+  uk_pop_all_vax$initial_conditions[, "S"] <- rep(0, 2)
+  uk_pop_all_vax$initial_conditions[, "V2"] <- rep((1 - 1e-6), 2)
+
+  # NOTE: defined as increasing transmission rate (baseline is 80% of unvaxxed)
+  waning_immunity <- function(time, x) x * ((1 + 0.001)^time)
+
+  data_all_vax <- model_vacamole(
+    uk_pop_all_vax,
+    mortality_rate = 0, hospitalisation_rate = 0
+  )
+  data_waning_immunity <- model_vacamole(
+    uk_pop_all_vax,
+    mortality_rate = 0, hospitalisation_rate = 0,
+    time_dependence = list(
+      transmission_rate_vax = waning_immunity
+    )
+  )
+
+  expect_true(
+    all(epidemic_size(data_waning_immunity) > epidemic_size(data))
   )
 })
 

--- a/tests/testthat/test-model_vacamole.R
+++ b/tests/testthat/test-model_vacamole.R
@@ -394,7 +394,7 @@ test_that("Vacamole model: time dependence", {
   )
 
   expect_true(
-    all(epidemic_size(data_waning_immunity) > epidemic_size(data))
+    all(epidemic_size(data_waning_immunity) > epidemic_size(data_all_vax))
   )
 })
 


### PR DESCRIPTION
This PR is related to #143:
1. Corrects the implementation of the Vacamole model C++ code by changing to a stricter accessor for the model infection parameter map;
2. Enables the use of rate interventions on all model infection parameters;
3. Enables the use of time-dependence on all model infection parameters;
4. Adds representative tests that check the statistical correctness of the vaccinated compartment, and that check that time-dependence works as expected on optional parameters not found in the default model.

This PR overrides #144 which restricted interventions to a smaller subset of parameters.