### PR TITLE
Improve C++ linting GHA workflow

### DIFF
--- a/.github/workflows/Cpp-lint-check.yaml
+++ b/.github/workflows/Cpp-lint-check.yaml
@@ -2,13 +2,11 @@
 # https://github.com/cpplint/GitHub-Action-for-cpplint
 
 on:
+  workflow_dispatch:
   push:
     paths:
      - "src/**"
      - "inst/include/**"
-  pull_request:
-    branches:
-      - "*"
 
 name: Cpp-lint-check
 


### PR DESCRIPTION
This PR edits the Cpp-lint-check workflow to dispatch in a similar way as the R-CMD-check workflow (with pushes to src/ or inst/include/).