### PR TITLE
fix link to `model_vacamole.html` vignette

### DIFF
--- a/vignettes/epidemics.Rmd
+++ b/vignettes/epidemics.Rmd
@@ -18,7 +18,7 @@ This initial vignette shows to get started with using the _epidemics_ package.
 
 Further vignettes include guidance on ["Modelling the implementation of vaccination regimes"](modelling_vaccination.html), as well as on["Modelling non-pharmaceutical interventions (NPIs) to reduce social contacts"](modelling_interventions.html) and ["Modelling multiple overlapping NPIs"](multiple_interventions.html).
 
-There is also guidance available on specific models in the model library, such as the [Vacamole model developed by RIVM, the Dutch Institute for Public Health](vacamole.html).
+There is also guidance available on specific models in the model library, such as the [Vacamole model developed by RIVM, the Dutch Institute for Public Health](model_vacamole.html).
 
 ```{r, include = FALSE}
 knitr::opts_chunk$set(


### PR DESCRIPTION
current link redirect to https://epiverse-trace.github.io/epidemics/articles/vacamole.html

is this the expected link? https://epiverse-trace.github.io/epidemics/reference/model_vacamole.html