### PR TITLE
Enhancements to `epidemic_size()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,4 +67,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-GB
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # epidemics (development version)
 
+## Breaking changes
+
+1. The default behaviour of `epidemic_size()` is to exclude the 'dead' compartment from epidemic size calculations; this has changed from including it by default, as most models don't have a 'dead' compartment (#212);
+
+## Helper functions
+
+1. `epidemic_size()` is substantially updated (#212):
+
+   - Added option for `time` which returns epidemic size at a specific time point, overriding the `stage` argument, defaults to `NULL` as the intended use of the function is to return the final size;
+
+   - Added option to return epidemic sizes at multiple stages or time points (`stage` and `time` can be vectors);
+
+   - Added option to simplify the output to a vector, which is `TRUE` by default to keep consistency with previous functionality;
+
+   - Added functionality to handle replicates from the Ebola model;
+
+   - Added tests for new functionality.
+
 # epidemics 0.2.0
 
 This is a second GitHub release of _epidemics_ which makes substantial additions to the functionality in v0.1.0, and introduces significant breaking changes (#176).

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -208,7 +208,7 @@ epidemic_size <- function(
   }
 
   # determine grouping columns to handle ebola model special case
-  grouping_cols <- c("time")
+  grouping_cols <- "time"
   if (by_group) {
     grouping_cols <- c(grouping_cols, "demography_group")
   }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -91,8 +91,8 @@
 #' @param data A table of model output, typically
 #' the output of [model_default()] or similar functions.
 #' @param stage A numeric vector for the stage of the epidemic at which to
-#' return the epidemic size; here, 0.0 represents the initial conditions of the
-#' epidemic (0% of model time), while 1.0 represents the end of the epidemic
+#' return the epidemic size; here, 0.0 represents the start time of the epidemic, i.e., the initial conditions of the
+#' epidemic simulation, while 1.0 represents the end of the epidemic simulation.
 #' model (100% of model time). Defaults to 1.0, at which stage returned values
 #' represent the _final size_ of the epidemic.
 #' This value is overridden by any values passed to the `time` argument.
@@ -111,7 +111,6 @@
 #' be simplified to a vector with one element for each demographic group.
 #' If the length of `stage` or `time` is $>$ 1, this argument is overridden and
 #' the data are returned as a `<data.table>`.
-#' group.
 #' @return
 #' If `simplify == TRUE` and a single timepoint is requested, returns a vector
 #' of epidemic sizes of the same length as the number of demographic groups.

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -91,10 +91,11 @@
 #' @param data A table of model output, typically
 #' the output of [model_de  ault()] or similar functions.
 #' @param stage A numeric vector for the stage of the epidemic at which to
-#' return the epidemic size; here, 0.0 represents the start time of the epidemic, i.e., the initial conditions of the
-#' epidemic simulation, while 1.0 represents the end of the epidemic simulation.
-#' model (100% of model time). Defaults to 1.0, at which stage returned values
-#' represent the _final size_ of the epidemic.
+#' return the epidemic size; here 0.0 represents the start time of the epidemic
+#' i.e., the initial conditions of the epidemic simulation, while 1.0 represents
+#' the end of the epidemic simulation model (100% of model time).
+#' Defaults to 1.0, at which stage returned values represent the _final size_ of
+#' the epidemic.
 #' This value is overridden by any values passed to the `time` argument.
 #' @param time Alternative to `stage`, an integer-like vector for the timepoint
 #' of the epidemic at which to return the epidemic size.

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -212,6 +212,7 @@ epidemic_size <- function(
   if (by_group) {
     grouping_cols <- c(grouping_cols, "demography_group")
   }
+  n_replicates <- 1 # set dummy value
   if ("replicate" %in% colnames(data)) {
     grouping_cols <- c(grouping_cols, "replicate")
     n_replicates <- max(data[["replicate"]])

--- a/man/epidemic_size.Rd
+++ b/man/epidemic_size.Rd
@@ -18,10 +18,11 @@ epidemic_size(
 the output of \code{\link[=model_de  ault]{model_de  ault()}} or similar functions.}
 
 \item{stage}{A numeric vector for the stage of the epidemic at which to
-return the epidemic size; here, 0.0 represents the initial conditions of the
-epidemic (0\% of model time), while 1.0 represents the end of the epidemic
-model (100\% of model time). Defaults to 1.0, at which stage returned values
-represent the \emph{final size} of the epidemic.
+return the epidemic size; here 0.0 represents the start time of the epidemic
+i.e., the initial conditions of the epidemic simulation, while 1.0 represents
+the end of the epidemic simulation model (100\% of model time).
+Defaults to 1.0, at which stage returned values represent the \emph{final size} of
+the epidemic.
 This value is overridden by any values passed to the \code{time} argument.}
 
 \item{time}{Alternative to \code{stage}, an integer-like vector for the timepoint

--- a/man/epidemic_size.Rd
+++ b/man/epidemic_size.Rd
@@ -50,9 +50,10 @@ of epidemic sizes of the same length as the number of demographic groups.
 If \code{by_group == FALSE}, sums the epidemic size to return an overall value for
 the full population.
 
-If multiple timepoints are requested, no simplification to a vector is
-possible; returns a \verb{<data.table>} of timepoints and epidemic sizes at each
-timepoint.
+If multiple timepoints are requested, or if multiple replicates are present
+under a specially named column "replicate" (only from the Ebola model), no
+simplification to a vector is possible; returns a \verb{<data.table>} of
+timepoints and epidemic sizes at each timepoint.
 
 All options return the absolute sizes and not proportions.
 }

--- a/man/epidemic_size.Rd
+++ b/man/epidemic_size.Rd
@@ -9,13 +9,13 @@ epidemic_size(
   stage = 1,
   time = NULL,
   by_group = TRUE,
-  include_deaths = TRUE,
+  include_deaths = FALSE,
   simplify = TRUE
 )
 }
 \arguments{
 \item{data}{A table of model output, typically
-the output of \code{\link[=model_default]{model_default()}} or similar functions.}
+the output of \code{\link[=model_de  ault]{model_de  ault()}} or similar functions.}
 
 \item{stage}{A numeric vector for the stage of the epidemic at which to
 return the epidemic size; here, 0.0 represents the initial conditions of the
@@ -24,8 +24,9 @@ model (100\% of model time). Defaults to 1.0, at which stage returned values
 represent the \emph{final size} of the epidemic.
 This value is overridden by any values passed to the \code{time} argument.}
 
-\item{time}{An optional numeric vector for the timepoint of the epidemic at
-which to return the epidemic size. Overrides any values passed to \code{stage}.}
+\item{time}{Alternative to \code{stage}, an integer-like vector for the timepoint
+of the epidemic at which to return the epidemic size.
+Overrides any values passed to \code{stage}.}
 
 \item{by_group}{A logical representing whether the epidemic size should be
 returned by demographic group, or whether a single population-wide value is
@@ -33,16 +34,15 @@ returned. Defaults to \code{TRUE}.}
 
 \item{include_deaths}{A logical value that indicates whether to count dead
 individuals in the epidemic size calculation.
-Defaults to \code{TRUE}, which makes the function look for a \code{"dead"} compartment
-in the data. If there is no such column, the function returns
-only the final number of recovered or removed individuals in each demographic
-group.}
+Defaults to \code{FALSE}. Setting \code{include_deaths = TRUE} makes the function look
+for a \code{"dead"} compartment in the data. If there is no such column, the
+function returns only the final number of recovered or removed individuals in
+each demographic group.}
 
 \item{simplify}{A logical determining whether the epidemic size data should
 be simplified to a vector with one element for each demographic group.
 If the length of \code{stage} or \code{time} is $>$ 1, this argument is overridden and
-the data are returned as a \verb{<data.table>}.
-group.}
+the data are returned as a \verb{<data.table>}.}
 }
 \value{
 If \code{simplify == TRUE} and a single timepoint is requested, returns a vector
@@ -87,9 +87,12 @@ data <- model_default(
   population = uk_population
 )
 
-# get the final epidemic size
+# get the final epidemic size if no other arguments are specified
 epidemic_size(data)
 
 # get the epidemic size at the halfway point
 epidemic_size(data, stage = 0.5)
+
+# alternatively, get the epidemic size at `time = 50`
+epidemic_size(data, time = 50)
 }

--- a/man/epidemic_size.Rd
+++ b/man/epidemic_size.Rd
@@ -4,17 +4,28 @@
 \alias{epidemic_size}
 \title{Get the epidemic size}
 \usage{
-epidemic_size(data, stage = 1, by_group = TRUE, include_deaths = TRUE)
+epidemic_size(
+  data,
+  stage = 1,
+  time = NULL,
+  by_group = TRUE,
+  include_deaths = TRUE,
+  simplify = TRUE
+)
 }
 \arguments{
 \item{data}{A table of model output, typically
 the output of \code{\link[=model_default]{model_default()}} or similar functions.}
 
-\item{stage}{The stage of the epidemic at which to return the epidemic size;
-here, 0.0 represents the initial conditions of the epidemic (0\% of model time
-), while 1.0 represents the end of the epidemic model (100\% of model time).
-The values returned at \code{stage = 1.0} represent the \emph{final size} of the
-epidemic.}
+\item{stage}{A numeric vector for the stage of the epidemic at which to
+return the epidemic size; here, 0.0 represents the initial conditions of the
+epidemic (0\% of model time), while 1.0 represents the end of the epidemic
+model (100\% of model time). Defaults to 1.0, at which stage returned values
+represent the \emph{final size} of the epidemic.
+This value is overridden by any values passed to the \code{time} argument.}
+
+\item{time}{An optional numeric vector for the timepoint of the epidemic at
+which to return the epidemic size. Overrides any values passed to \code{stage}.}
 
 \item{by_group}{A logical representing whether the epidemic size should be
 returned by demographic group, or whether a single population-wide value is
@@ -26,11 +37,24 @@ Defaults to \code{TRUE}, which makes the function look for a \code{"dead"} compa
 in the data. If there is no such column, the function returns
 only the final number of recovered or removed individuals in each demographic
 group.}
+
+\item{simplify}{A logical determining whether the epidemic size data should
+be simplified to a vector with one element for each demographic group.
+If the length of \code{stage} or \code{time} is $>$ 1, this argument is overridden and
+the data are returned as a \verb{<data.table>}.
+group.}
 }
 \value{
-A single number when \code{by_group = FALSE}, or a vector of numbers of
-the same length as the number of demographic groups when \code{by_group = TRUE}.
-Returns the absolute sizes and not proportions.
+If \code{simplify == TRUE} and a single timepoint is requested, returns a vector
+of epidemic sizes of the same length as the number of demographic groups.
+If \code{by_group == FALSE}, sums the epidemic size to return an overall value for
+the full population.
+
+If multiple timepoints are requested, no simplification to a vector is
+possible; returns a \verb{<data.table>} of timepoints and epidemic sizes at each
+timepoint.
+
+All options return the absolute sizes and not proportions.
 }
 \description{
 Get the size of the epidemic at any stage between the start and the end.

--- a/tests/testthat/test-epidemic_size.R
+++ b/tests/testthat/test-epidemic_size.R
@@ -121,3 +121,32 @@ test_that("Epidemic size with no deaths is correct", {
     epidemic_size(data)
   )
 })
+
+test_that("Epidemic size for ebola model with replicates", {
+  # prepare data
+  demography_vector <- 67000
+  replicates <- 100L
+
+  pop <- population(
+    contact_matrix = matrix(1),
+    demography_vector = demography_vector,
+    initial_conditions = matrix(
+      c(1 - 1e-3, 1e-3 / 2, 1e-3 / 2, 0, 0, 0),
+      nrow = 1
+    )
+  )
+
+  # expect that function returns data.table when replicates > 1
+  output <- model_ebola(pop, replicates = replicates)
+  data <- epidemic_size(output, simplify = TRUE)
+
+  expect_s3_class(data, "data.table")
+  expect_identical(
+    nrow(data), replicates
+  )
+
+  # expect that output can be simplified when replicates = 1
+  output <- model_ebola(pop, replicates = 1L)
+  data <- epidemic_size(output, simplify = TRUE)
+  expect_vector(data, numeric())
+})

--- a/tests/testthat/test-epidemic_size.R
+++ b/tests/testthat/test-epidemic_size.R
@@ -19,10 +19,11 @@ uk_population <- population(
   initial_conditions = initial_conditions
 )
 
+time_end <- 200
 # run epidemic simulation with no vaccination or intervention
 data <- model_default(
   population = uk_population,
-  time_end = 200,
+  time_end = time_end,
   increment = 1
 )
 
@@ -34,6 +35,11 @@ test_that("Epidemic size functions", {
     initial_conditions[, "infectious"],
     ignore_attr = TRUE
   )
+  expect_equal(
+    epidemic_size(data, time = 0),
+    epidemic_initial_size,
+    ignore_attr = TRUE
+  )
 
   # test the final size
   epidemic_final_size <- epidemic_size(data)
@@ -41,6 +47,25 @@ test_that("Epidemic size functions", {
     epidemic_final_size,
     data[data$compartment == "recovered" & data$time == max(data$time), ]$value,
     ignore_attr = TRUE
+  )
+  expect_equal(
+    epidemic_size(data, time = time_end),
+    epidemic_final_size,
+    ignore_attr = TRUE
+  )
+
+  # expect return types and contents
+  expect_s3_class(
+    epidemic_size(data, simplify = FALSE),
+    "data.table"
+  )
+  expect_s3_class(
+    epidemic_size(data, by_group = FALSE, simplify = FALSE),
+    "data.table"
+  )
+  expect_s3_class(
+    epidemic_size(data, time = c(1, 2), simplify = TRUE),
+    "data.table"
   )
 
   # expect that the final size proportion is the same as the demography prop.


### PR DESCRIPTION
This PR addresses issues raised in #190:

1. `epidemic_size()` now optionally returns a `<data.table>` of epidemic sizes at specified timepoints via the logical `simplify` argument; the default behaviour remains returning a numeric vector (for backwards compatibility);
2. Epidemic sizes at multiple timepoints can be requested by passing a vector to `stage`;
3. Epidemic sizes can be requested at specific timepoints (e.g. $t = 100, 200, 300$) instead of a proportion of epidemic time;
4. A data.table is automatically returned, overriding the `simplify` argument, if a vector is passed to `stage` or `time`.