### PR TITLE
Fix pkgdown YAML

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,8 +1,11 @@
 url: https://epiverse-trace.github.io/epidemics/
 template:
+  bootstrap: 5
   bslib:
     font_weight_base : 300
   package: epiversetheme
+development:
+  mode: auto
 articles:
 - title: Modelling interventions
   navbar: Modelling interventions


### PR DESCRIPTION
This PR adds a manual specification of the Bootstrap version (v5) for the pkgdown website, due to a breaking change in pkgdown.