### PR TITLE
Fix vaccination leading to negative susceptibles

### DIFF
--- a/inst/include/model_default.h
+++ b/inst/include/model_default.h
@@ -112,8 +112,8 @@ struct epidemic_default {
     vax_nu_current =
         vaccination::current_nu(t, vax_nu, vax_time_begin, vax_time_end);
 
-    // NB: Casting initial conditions matrix columns to arrays is necessary
-    // for vectorised operations
+    /// NOTE: Casting initial conditions matrix columns to arrays is necessary
+    /// for vectorised operations
 
     // compartmental transitions without accounting for contacts
     Eigen::ArrayXd sToE = model_params_temp.at("transmission_rate") *
@@ -124,7 +124,9 @@ struct epidemic_default {
         model_params_temp.at("recovery_rate") * x.col(2).array();
 
     /// NOTE: vax_nu_current holds COUNTS, not rates. See issue #198 for details
-    Eigen::ArrayXd sToV = vax_nu_current.col(0).array();
+    // S -> V is the group-wise minimum of doses or individuals
+    // preventing negative values in S
+    Eigen::ArrayXd sToV = x.col(0).array().min(vax_nu_current.col(0).array());
 
     // compartmental changes accounting for contacts (for dS and dE)
     // β: transmission_rate; ν: vaccination COUNTS, see issue #198

--- a/inst/include/model_vacamole.h
+++ b/inst/include/model_vacamole.h
@@ -143,10 +143,11 @@ struct epidemic_vacamole {
                           (cm_temp * (x.col(5) + x.col(6))).array();
 
     /// NOTE: vax_nu_current holds COUNTS, not rates. See issue #198 for details
+    // individuals vaccinated are the group-wise minimum of doses or individuals
     // Susceptible to vaccinated with one dose
-    Eigen::ArrayXd sToV1 = vax_nu_current.col(0).array();
+    Eigen::ArrayXd sToV1 = x.col(0).array().min(vax_nu_current.col(0).array());
     // Vaccinated one dose to vaccinated with two doses
-    Eigen::ArrayXd v1ToV2 = vax_nu_current.col(1).array();
+    Eigen::ArrayXd v1ToV2 = x.col(1).array().min(vax_nu_current.col(1).array());
 
     // Vaccinated one dose to exposed - same as susceptible to exposed
     Eigen::ArrayXd v1ToE = model_params_temp.at("transmission_rate") *

--- a/tests/testthat/test-model_default.R
+++ b/tests/testthat/test-model_default.R
@@ -243,6 +243,22 @@ test_that("Default model: vaccination and stats. correctness", {
   expect_true(
     all(epidemic_size(data_baseline) > epidemic_size(data))
   )
+
+  # expect that high vaccination rates (± 1% per day, e.g. Covid-19 vax)
+  # give statistically correct results (no negative susceptibles at any time)
+  high_rate_vax <- vaccination(
+    time_begin = matrix(200, nrow(contact_matrix)),
+    time_end = matrix(200 + 150, nrow(contact_matrix)),
+    nu = matrix(0.01, nrow = nrow(contact_matrix))
+  )
+  data <- model_default(
+    uk_population,
+    vaccination = high_rate_vax, time_end = 600
+  )
+  checkmate::expect_numeric(
+    data[grepl("susceptible", data$compartment, fixed = TRUE), ]$value,
+    lower = 0
+  )
 })
 
 test_that("Default model: time dependence", {

--- a/tests/testthat/test-model_vacamole.R
+++ b/tests/testthat/test-model_vacamole.R
@@ -343,6 +343,31 @@ test_that("Vacamole model: two dose vaccination and stats. correctness", {
     data[grepl("dose", data$compartment, fixed = TRUE) &
       time %in% seq(50, 55), ]
   )
+
+  # expect that high vaccination rates (± 1% per day, e.g. Covid-19 vax)
+  # give statistically correct results (no negative susceptibles at any time)
+  high_rate_vax <- vaccination(
+    nu = matrix(
+      c(1e-2, 1e-2), # 1% per day
+      nrow = 2, ncol = 2, byrow = TRUE
+    ),
+    time_begin = matrix(
+      c(0, 50),
+      nrow = 2, ncol = 2, byrow = TRUE # second dose given from t = 50 onwards
+    ),
+    time_end = matrix(
+      100,
+      nrow = 2, ncol = 2
+    )
+  )
+  data <- model_vacamole(
+    uk_population,
+    vaccination = high_rate_vax, time_end = 600
+  )
+  checkmate::expect_numeric(
+    data[grepl("susceptible", data$compartment, fixed = TRUE), ]$value,
+    lower = 0
+  )
 })
 
 test_that("Vacamole model: time dependence", {

--- a/vignettes/modelling_vaccination.Rmd
+++ b/vignettes/modelling_vaccination.Rmd
@@ -22,8 +22,6 @@ knitr::opts_chunk$set(
 
 ```{r setup}
 library(epidemics)
-library(dplyr)
-library(ggplot2)
 ```
 
 ## Prepare population and initial conditions
@@ -96,7 +94,15 @@ vaccinate_elders <- vaccination(
 vaccinate_elders
 ```
 
-## Run epidemic model
+::: {.alert .alert-warning}
+**Note that** when the vaccination rate is high, the number of individuals who could _potentially_ transition from 'susceptible' to 'vaccinated' may be greater than the number of individuals in the 'susceptible' compartment: $dS_{i_{t}} = \nu_{i_t}S_{i_{0}} > S_{i_{t}}$ for each demographic group $i$ at time $t$.
+
+This could realistically occur when there are more doses available than individuals eligible to receive them, for instance towards the end of an epidemic.
+
+_epidemics_ automatically handles such situations by setting $dS_{i_{t}}$ to be the minimum of doses or eligible individuals: : $dS_{i_t} = \text{Min}(\nu_{i_t}S_{i_0}, S_{i_t})$, such that $S_{i_{t+1}}$ does not take a negative value.
+:::
+
+The `<vaccination>` object can be passed to the `vaccination` argument of a model function call.
 
 ```{r}
 # run an epidemic model using `epidemic`
@@ -107,42 +113,6 @@ output <- model_default(
 )
 ```
 
-## Prepare data and visualise infections
-
-Plot epidemic over time, showing only the number of individuals in the exposed, infected, and vaccinated compartments.
-
-```{r class.source = 'fold-hide'}
-# plot figure of epidemic curve
-filter(output, compartment %in% c("exposed", "infectious")) %>%
-  ggplot(
-    aes(
-      x = time,
-      y = value,
-      col = demography_group,
-      linetype = compartment
-    )
-  ) +
-  geom_line() +
-  scale_y_continuous(
-    labels = scales::comma
-  ) +
-  scale_colour_brewer(
-    palette = "Dark2",
-    name = "Age group"
-  ) +
-  expand_limits(
-    y = c(0, 500e3)
-  ) +
-  coord_cartesian(
-    expand = FALSE
-  ) +
-  theme_bw() +
-  theme(
-    legend.position = "top"
-  ) +
-  labs(
-    x = "Simulation time (days)",
-    linetype = "Compartment",
-    y = "Individuals"
-  )
-```
+::: {.alert .alert-info}
+**Note that** vaccination modelling is currently only supported for the 'default' (`model_default()`) and 'Vacamole' (`model_vacamole()`) models.
+:::


### PR DESCRIPTION
This PR fixes #226. A reprex copied from #224 where this issue was first reported is attached.

``` r
library(epidemics)
library(socialmixr)
#> 
#> Attaching package: 'socialmixr'
#> The following object is masked from 'package:utils':
#> 
#>     cite
library(tidyverse)

preinfectious_period <- 3.0
infectious_period <- 7.0
basic_reproduction <- 1.46

infectiousness_rate <- 1.0/preinfectious_period
recovery_rate <- 1.0/infectious_period
transmission_rate <- basic_reproduction/infectious_period

polymod <- socialmixr::polymod
contact_data <- socialmixr::contact_matrix(
  polymod,
  countries = "Italy",
  age.limits = c(0, 20, 40),
  symmetric = TRUE
)
#> Using POLYMOD social contact data. To cite this in a publication, use the 'cite' function
#> Removing participants without age information. To change this behaviour, set the 'missing.participant.age' option
#> Removing participants that have contacts without age information. To change this behaviour, set the 'missing.contact.age' option

# prepare contact matrix
contact_matrix <- t(contact_data$matrix)

# prepare the demography vector
demography_vector <- contact_data$demography$population
names(demography_vector) <- rownames(contact_matrix)

# initial conditions: one in every 1 million is infected
initial_i <- 1e-6
initial_conditions <- c(
  S = 1 - initial_i, E = 0, I = initial_i, R = 0, V = 0
)

initial_conditions <- matrix(
  rep(initial_conditions, dim(contact_matrix)[1]),
  ncol = 5, byrow = TRUE
)

italy_population <- population(
  contact_matrix = contact_matrix,
  demography_vector = demography_vector,
  initial_conditions = initial_conditions
)

vaccinate <- vaccination(
  name = "vaccinate all",
  time_begin = matrix(200, nrow(contact_matrix)),
  time_end = matrix(200 + 150, nrow(contact_matrix)),
  nu = matrix(c(0.01, 0.0, 0.01))
)

intervention_vaccine <- model_default(
  # population
  population = italy_population,
  # rates
  transmission_rate = transmission_rate,
  infectiousness_rate = infectiousness_rate,
  recovery_rate = recovery_rate,
  # intervention
  vaccination = vaccinate,
  # time
  time_end = 600,increment = 1
)

intervention_vaccine %>% 
  filter(compartment == "infectious") %>% 
  ggplot(aes(x = time, y = value, colour = demography_group)) +
  geom_line()
```

![](https://i.imgur.com/Mn2xDET.png)<!-- -->

<sup>Created on 2024-05-24 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>