### PR TITLE
Update vignettes to reflect odin replacement of Rcpp

### DIFF
--- a/vignettes/design-principles.Rmd
+++ b/vignettes/design-principles.Rmd
@@ -29,7 +29,7 @@ _epidemics_ aims to help public health practitioners - rather than research-focu
 
  - _epidemics_ trades away some flexibility in defining model structures for a gain in the ease of defining epidemic scenario components such as affected populations and model events.
 
- - _epidemics_ attempts to balance performance and maintainability through minimum sufficient use of C++, and not attempting to write a domain-specific language (such as [_odin_](https://cran.r-project.org/package=odin)).
+ - _epidemics_ aims to balance performance and maintainability by leveraging the [odin](https://cran.r-project.org/package=odin) language for solving ODEs rather than  relying on C++ implementations.
 
  - To be more broadly applicable, _epidemics_ provides a 'library' of compartmental models which are adapted from the published literature. These models focus on broad types of diseases or settings, rather than specific diseases or scenarios. Thus all models are intended to be applicable to a range of diseases.
 
@@ -77,19 +77,18 @@ The notes here refer to broad decisions and not to individual models -- see indi
 
 - It is possible to write ODE compartmental transitions in C++, and expose the C++ code to R, eventually passing this ODE system to deSolve solvers (referred to as 'Rcpp-deSolve'). We have also opted against this approach, as it involves substantial interconversion of more complex objects such as structured lists (the model composable elements) from R to C++ in each solver timestep, reducing performance.
 
-- ODE systems are written in C++, and solved using the [Boost _odeint_ solvers](https://www.boost.org/doc/libs/1_84_0/libs/numeric/odeint/doc/html/index.html) with *fixed step sizes*. This means that within each call to `model_*()`, R objects are converted for use by C++ only once (in the scalar arguments case), and are not passed back and forth multiple times.
+To improve **usability, modularity** and **maintainability**, the `epidemics` package has adopted [odin](https://mrc-ide.github.io/odin/) as its core tool for defining and solving **ordinary differential equations (ODEs)**. `odin` is a domain-specific language embedded in `R` that allows users to write ODE models in a conscience and readable way, while generating efficient `C` code internally.
 
-- _odeint_ is provided by the package [BH (Boost Headers)](https://cran.r-project.org/package=BH), making it convenient to use in Rcpp packages. The [_r2sundials_ package](https://cran.r-project.org/package=r2sundials) provides an Rcpp-friendly interface to the [SUNDIALS ODE solvers](https://computing.llnl.gov/projects/sundials), but the documentation is less clear overall, and seems to recommend the use of [_RcppArmadillo_](https://cran.r-project.org/package=RcppArmadillo) and [_RcppXPtrUtils_](https://cran.r-project.org/package=RcppXPtrUtils); these have not been evaluated for use.
+Why we adopted `odin`:
 
-- _odeint_ imposes certain constraints on ODE systems. There is no functionality to easily define 'events' (also called 'callbacks') and combine them with the ODE system. This means that the ODE systems have to encapsulate information on the timing of events (such as interventions) and the effect.
+-  **seamless integration with `R`**: ODE models are written directly in `R` using `odin`, which resembles basic `R` syntax but is designed for deterministic compartmental models.
 
-- Equations describing **the right-hand side of model ODE systems** $x' = f(x)$ are thus written as [`structs`](https://cplusplus.com/doc/tutorial/structures/) with an [overloaded function call operator](https://en.cppreference.com/w/cpp/language/operators) that makes them [`FunctionObject` types](https://en.cppreference.com/w/cpp/named_req/FunctionObject). The `struct` thus holds epidemiological parameters and composable elements, which are passed by reference in any operations, reducing copying. [See this simple example from the Boost documentation.](https://live.boost.org/doc/libs/1_84_0/libs/numeric/odeint/doc/html/boost_numeric_odeint/getting_started/short_example.html) It can be passed as a function to a solver, and the epidemiological parameters are calculated in each solver timestep as **some function of time and the composable elements** (as applicable). 
+-  **Automatic compilation**: When `odin` model is defined, it is compiled to `C` (not C++) and linked into `R` automatically. This means you get the speed of compiled code without needing to write any `C` or `C++` yourself.
 
-- _epidemics_ relies on the Eigen C++ library provided by RcppEigen to represent matrices of initial conditions. Eigen matrices are among the types accepted as initial states by _odeint_ solvers. Alternatives include Boost Basic Linear Algebra Library (uBLAS) and standard library arrays and vectors; [a partial list - which does not include Eigen - is provided by Boost](https://live.boost.org/doc/libs/1_84_0/libs/numeric/odeint/doc/html/boost_numeric_odeint/getting_started/overview.html), and Armadillo matrices may also be supported. We use Eigen matrices as Eigen offers broad and well documented support for matrix operations, easy conversion between Rcpp types, and also conforms to previous use of Eigen in [_finalsize_](https://cran.r-project.org/package=finalsize).
+-  **Built-in solver**: `odin` uses its own solver (`dust` for stochastic models and `odin.dust` for solving ODEs), removing the need to depend on external packages like [deSolve]([_deSolve_ package](https://cran.r-project.org/package=deSolve)) or [Boost _odeint_ solvers](https://www.boost.org/doc/libs/1_84_0/libs/numeric/odeint/doc/html/index.html).
 
-- The models' C++ code is in two levels that underlie the R source code - the C++ source code and the C++ headers. This is to make the header code (the model ODEs and helper functions) shareable so that they can be re-used in other Rcpp packages and [this is explored more in this blog post.](https://epiverse-trace.github.io/posts/share-cpp/)
+-  **Composable design**: The `epidemics` package retains its modular structure - interventions, time-varying parametrs and vaccination effects are defined as separate components that can be combined dynamically with the core `odin` models.
 
-- _epidemics_ defines C++ namespaces in the package headers to more clearly indicate where certain functionalities sit. All model structures are in the namespace `epidemics`, while the namespaces `vaccination`, `intervention`, and `time_dependence` contain C++ code to handle these composable elements (such as calculating the effect of cumulative interventions). The namespace `odetools` defines the initial state type, which is an `Eigen::MatrixXd`.
 
 ### Stochastic models
 
@@ -164,7 +163,7 @@ _epidemics_ is moving towards allowing vectors or lists to be passed as model fu
 
 - Function naming: Function names aim to contain verbs that indicate the function behaviour. Internal input checking functions follow the _checkmate_ naming style (e.g. `assert_*()`).
 
-- Function naming: Internal functions aim to begin with a `.` (e.g. `.model_default_cpp()`) to more clearly indicate that they are not for direct use.
+- Function naming: Internal functions aim to begin with a `.` (e.g. .model_default_cpp()) to more clearly indicate that they are not for direct use.
 
 ---
 
@@ -197,3 +196,4 @@ A wider range of packages are taken on as soft dependencies to make the vignette
 
 There are no special requirements to contributing to _epidemics_, but contributions of new models should be clearly motivated, fall within the scope of the package, target a disease type or situation that is not already covered by existing models, and ideally should already be peer-reviewed.
 In general, please follow the [package contributing guide](https://github.com/epiverse-trace/.github/blob/main/CONTRIBUTING.md).
+


### PR DESCRIPTION
##  Description
This PR updates the `design-principles.Rmd` vignette to:

- Reflect the package's transition to odin for ODE modeling
- Clarify the new architecture and modular design
- Removed deprecated references to `deSolve`/`Boost odeint`.
- Document the shift from `Rcpp`/`deSolve` to `odin`'s domain-specific language
- Updated scope to reflect `odin` implementation


