### PR TITLE
Update `codecov/codecov-action` variables to fix CI workflow

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -65,8 +65,8 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
-          file: ./cobertura.xml
-          plugin: noop
+          files: ./cobertura.xml
+          plugins: noop
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [X] I have read the CONTRIBUTING guidelines
- ~[ ] A new item has been added to `NEWS.md`~ _Not applicable_
- ~[ ] Tests for the changes have been added (for bug fixes / features)~ _Not applicable_
- ~[ ] Docs have been added / updated (for bug fixes / features)~ _Not applicable_
- [X] Checks have been run locally and pass

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Since merging PR #284 the codecov workflow has been failing on GitHub actions with the error message: `Error: Error: No coverage reports found. Please make sure you're generating reports successfully.`. 

This PR updates two variables for `codecov/codecov-action@7` in `test-coverage.yaml` to hopefully fix the failing CI workflow.

* **What is the current behavior?** (You can also link to an open issue here)

Failing test-coverage CI workflow.

* **What is the new behavior (if this is a feature change)?**

Passing test-coverage CI workflow. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.
