### PR TITLE
Add `persist-credentials: false` to fix `update-citation-cff.yaml` CI

### DIFF
--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -25,6 +25,13 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          # checkout v6+ persists git credentials in a way that collides with
+          # the Authorization header set by peter-evans/create-pull-request,
+          # producing a duplicate header and an HTTP 400 on push. Disabling
+          # credential persistence leaves the create-pull-request token in sole
+          # control of authentication.
+          persist-credentials: false
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [X] I have read the CONTRIBUTING guidelines
- ~[ ] A new item has been added to `NEWS.md`~ _Not applicable_
- ~[ ] Tests for the changes have been added (for bug fixes / features)~ _Not applicable_
- ~[ ] Docs have been added / updated (for bug fixes / features)~ _Not applicable_
- [X] Checks have been run locally and pass

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Since merging PR #287 the `update-citation-cff.yaml` GitHub actions workflow is failing with the error message: 

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/epiverse-trace/epidemics/': The requested URL returned error: 400
Error: The process '/usr/bin/git' failed with exit code 128
```

This is due to incompatibility in autorisation issue between `actions/checkout` >v6 and `peter-evens/create-pull-request`.

The solution (from https://github.com/peter-evans/create-pull-request/issues/4228#issuecomment-3564017176) is to add `persist-credentials: false` as a variable to `actions/checkout@v7`. 

* **What is the current behavior?** (You can also link to an open issue here)

Failing `update-citation-cff.yaml` CI workflow.

* **What is the new behavior (if this is a feature change)?**

Passing `update-citation-cff.yaml` CI workflow.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.
